### PR TITLE
Added depsolve celery task

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 pytest
 requests
-mock

--- a/tests/test_pulp_queries.py
+++ b/tests/test_pulp_queries.py
@@ -5,35 +5,29 @@ from ubi_manifest.worker.tasks.depsolver.models import UbiUnit
 from ubi_manifest.worker.tasks.depsolver.pulp_queries import (
     _search_units,
     _search_units_per_repos,
-    make_pulp_client,
     search_modulemds,
     search_rpms,
 )
-from ubi_manifest.worker.tasks.depsolver.utils import create_or_criteria
+from ubi_manifest.worker.tasks.depsolver.utils import (
+    create_or_criteria,
+    make_pulp_client,
+)
 
 from .utils import create_and_insert_repo
 
 
-@define
-class TestConfig:
-    url: str
-    username: str
-    password: str
-    insecure: bool
-
-
 def test_make_pulp_client():
-    config = TestConfig(
-        url="https://fake.pulp.com",
-        username="test_user",
-        password="test_pass",
-        insecure=True,
-    )
+    config = {
+        "url": "https://fake.pulp.com",
+        "username": "test_user",
+        "password": "test_pass",
+        "insecure": True,
+    }
+    with make_pulp_client(**config) as client:
+        client = make_pulp_client(**config)
 
-    client = make_pulp_client(config)
-
-    # Client instance is prperly created with no errors
-    assert isinstance(client, Client)
+        # Client instance is prperly created with no errors
+        assert isinstance(client, Client)
 
 
 def test_search_rpms(pulp):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,91 @@
-from ubi_manifest.worker.tasks.dummy_task import dummy_task
+from unittest import mock
+
+from pubtools.pulplib import RpmUnit
+
+from ubi_manifest.worker.tasks import depsolve
+
+from .utils import MockLoader, create_and_insert_repo
 
 
-def test_dummy_task():
-    result = dummy_task()
-    assert result == "CELERY_OK"
+def test_depsolve_task(pulp):
+    with mock.patch(
+        "pubtools.pulplib.YumRepository.get_debug_repository"
+    ) as get_debug_mock:
+        ubi_repo = create_and_insert_repo(
+            id="ubi_repo",
+            pulp=pulp,
+            population_sources=["rhel_repo"],
+            relative_url="foo/bar/os",
+            ubi_config_version="8.4",
+            content_set="rpm_in",
+        )
+        rhel_repo = create_and_insert_repo(id="rhel_repo", pulp=pulp)
+
+        ubi_debug_repo = create_and_insert_repo(
+            id="ubi_debug_repo",
+            pulp=pulp,
+            population_sources=["rhel_debug_repo"],
+            relative_url="foo/bar/debug",
+        )
+        rhel_debug_repo = create_and_insert_repo(id="rhel_debug_repo", pulp=pulp)
+
+        get_debug_mock.return_value = ubi_debug_repo
+
+        ubi_repo.get_debug_repository = mock.MagicMock()
+        ubi_repo.get_debug_repository.return_value = ubi_debug_repo
+
+        unit_binary = RpmUnit(
+            name="gcc",
+            version="10",
+            release="200",
+            epoch="1",
+            arch="x86_64",
+            sourcerpm="gcc_src-1-0.src.rpm",
+            requires=[],
+            provides=[],
+        )
+
+        unit_debuginfo = RpmUnit(
+            name="gcc-debuginfo",
+            version="10",
+            release="200",
+            epoch="1",
+            arch="x86_64",
+            requires=[],
+            provides=[],
+        )
+        unit_debugsource = RpmUnit(
+            name="gcc_src-debugsource",
+            version="10",
+            release="200",
+            epoch="1",
+            arch="x86_64",
+            requires=[],
+            provides=[],
+        )
+
+        pulp.insert_units(rhel_repo, [unit_binary])
+        pulp.insert_units(rhel_debug_repo, [unit_debuginfo, unit_debugsource])
+
+        with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+            with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
+                client.return_value = pulp.client
+                # let run the depsolve task
+                result = depsolve.depsolve_task(["ubi_repo"])
+
+                # there should be 2 repos in output - one binary and one debuginfo
+                assert sorted(list(result.keys())) == ["ubi_debug_repo", "ubi_repo"]
+
+                # binary repo contains only one rpm
+                content = result["ubi_repo"]
+                assert len(content) == 1
+                unit = content[0]
+                assert unit.name == "gcc"
+
+                # debuginfo repo conains two debug packages
+                content = sorted(result["ubi_debug_repo"], key=lambda x: x.name)
+                assert len(content) == 2
+                unit = content[0]
+                assert unit.name == "gcc-debuginfo"
+                unit = content[1]
+                assert unit.name == "gcc_src-debugsource"

--- a/tests/test_ubi_config.py
+++ b/tests/test_ubi_config.py
@@ -1,11 +1,12 @@
-import ubiconfig
-from mock import patch
+from unittest import mock
 
 from ubi_manifest.worker.tasks.depsolver.ubi_config import UbiConfigLoader
 
+from .utils import MockLoader
+
 
 def test_get_config():
-    with patch("ubiconfig.get_loader", return_value=MockLoader()) as mock_loader:
+    with mock.patch("ubiconfig.get_loader", return_value=MockLoader()) as mock_loader:
         loader = UbiConfigLoader("https://foo.bar.com/some-repo.git")
         config = loader.get_config("rpm_out", "8")
 
@@ -32,22 +33,3 @@ def test_get_config():
         # mock_loader ("ubiconfig.get_loader") should be called only once
         # second call of loader.get_config() reads from loader._config_map
         mock_loader.assert_called_once()
-
-
-class MockLoader:
-    def load_all(self):
-        config_raw = {
-            "modules": {},
-            "packages": {
-                "include": ["package-name-.*"],
-                "exclude": ["package-name-.*"],
-                "arches": ["arch"],
-            },
-            "content_sets": {
-                "rpm": {"output": "rpm_out", "input": "rpm_in"},
-                "srpm": {"output": "srpm_out", "input": "srpm_in"},
-                "debuginfo": {"output": "debug_out", "input": "debug_in"},
-            },
-        }
-
-        return [ubiconfig.UbiConfig.load_from_dict(config_raw, "foo", "8")]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from ubi_manifest.worker.tasks.depsolver.utils import (
     flatten_list_of_sets,
     get_n_latest_from_content,
     parse_bool_deps,
+    split_filename,
     vercmp_sort,
 )
 
@@ -310,3 +311,34 @@ def test_create_or_criteria_uneven_args():
     # in value list
     with pytest.raises(ValueError):
         _ = create_or_criteria(fields, values)
+
+
+@pytest.mark.parametrize(
+    "filename, name, ver, rel, epoch, arch",
+    [
+        (
+            "32:bind-9.10.2-2.P1.fc22.x86_64.rpm",
+            "bind",
+            "9.10.2",
+            "2.P1.fc22",
+            "32",
+            "x86_64",
+        ),
+        (
+            "bind-9.10.2-2.P1.fc22.x86_64.rpm",
+            "bind",
+            "9.10.2",
+            "2.P1.fc22",
+            "",
+            "x86_64",
+        ),
+    ],
+)
+def test_split_filename(filename, name, ver, rel, epoch, arch):
+    result = split_filename(filename)
+
+    assert result[0] == name
+    assert result[1] == ver
+    assert result[2] == rel
+    assert result[3] == epoch
+    assert result[4] == arch

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import ubiconfig
 from pubtools.pulplib import YumRepository
 
 
@@ -6,3 +7,22 @@ def create_and_insert_repo(**kwargs):
     pulp.insert_repository(YumRepository(**kwargs))
 
     return pulp.client.get_repository(kwargs["id"])
+
+
+class MockLoader:
+    def load_all(self):
+        config_raw = {
+            "modules": {},
+            "packages": {
+                "include": ["package-name-.*", "gcc.*", "httpd.src", "pkg-debuginfo.*"],
+                "exclude": ["package-name-.*", "kernel"],
+            },
+            "content_sets": {
+                "rpm": {"output": "rpm_out", "input": "rpm_in"},
+                "srpm": {"output": "srpm_out", "input": "srpm_in"},
+                "debuginfo": {"output": "debug_out", "input": "debug_in"},
+            },
+            "arches": ["x86_64", "src"],
+        }
+
+        return [ubiconfig.UbiConfig.load_from_dict(config_raw, "foo", "8")]

--- a/ubi_manifest/worker/tasks/celery.py
+++ b/ubi_manifest/worker/tasks/celery.py
@@ -1,14 +1,6 @@
-import os
-
 import celery
 
+from ubi_manifest.worker.tasks.config import make_config
 
-def celery_init():
-    return celery.Celery(
-        broker=os.getenv("CELERY_BROKER", "redis://localhost:6379/0"),
-        backend=os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
-        include=["ubi_manifest.worker.tasks.dummy_task"],
-    )
-
-
-app = celery_init()
+app = celery.Celery()
+make_config(app)

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -1,0 +1,30 @@
+import configparser
+import os
+from typing import List
+
+from attrs import define
+
+
+@define
+class Config:
+    pulp_url: str = "some_url"
+    pulp_username: str = "username"
+    pulp_password: str = "pass"
+    pulp_insecure: bool = False
+    ubi_config_url: str = "some_url"
+    allowed_ubi_repos: dict = None
+    include: List[str] = ["ubi_manifest.worker.tasks.depsolve_task"]
+    broker: str = "redis://localhost:6379/0"
+    backend: str = "redis://localhost:6379/0"
+
+
+def make_config(celery_app):
+    config_file = os.getenv("UBI_MANIFEST_CONFIG", "/etc/ubi_manifest/app.conf")
+    config_from_file = configparser.ConfigParser()
+    config_from_file.read(config_file)
+    try:
+        config = Config(**dict(config_from_file["CONFIG"]))
+    except KeyError:
+        config = Config()
+
+    celery_app.config_from_object(config, force=True)

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Dict, List
+
+from ubi_manifest.worker.tasks.celery import app
+from ubi_manifest.worker.tasks.depsolver.models import DepsolverItem, UbiUnit
+from ubi_manifest.worker.tasks.depsolver.rpm_depsolver import Depsolver
+from ubi_manifest.worker.tasks.depsolver.ubi_config import UbiConfigLoader
+from ubi_manifest.worker.tasks.depsolver.utils import (
+    make_pulp_client,
+    remap_keys,
+    split_filename,
+)
+
+_LOG = logging.getLogger(__name__)
+
+
+@app.task
+def depsolve_task(ubi_repo_ids: List[str]) -> Dict[str, List[UbiUnit]]:
+    """
+    Run depsolvers for given ubi_repo_ids. Debuginfo repos related to those provide
+    as parameter are automatically resolved as well. Returns a dictionary where key is
+    a destination ubi_repo_id, value is a list of UbiUnit that should appear in
+    the repository.
+    """
+    ubi_config_loader = UbiConfigLoader(app.conf["ubi_config_url"])
+
+    with make_pulp_client(
+        app.conf["pulp_url"],
+        app.conf["pulp_username"],
+        app.conf["pulp_password"],
+        app.conf["pulp_insecure"],
+    ) as client:
+        repos_map = {}
+        debuginfo_dep_map = {}
+        dep_map = {}
+
+        for ubi_repo_id in ubi_repo_ids:
+            repo = client.get_repository(ubi_repo_id)
+            debuginfo_repo = repo.get_debug_repository()
+            version = repo.ubi_config_version
+            # get proper ubi_config for given content_set and version
+            config = ubi_config_loader.get_config(repo.content_set, version)
+            # config not found for specific version, try to fallback to default version
+            if config is None:
+                config = ubi_config_loader.get_config(
+                    repo.content_set, version.split(".")[0]
+                )
+            # create rhel_repo:ubi_repo mapping
+            for _repo, sources in zip(
+                [repo, debuginfo_repo],
+                [repo.population_sources, debuginfo_repo.population_sources],
+            ):
+                for item in sources:
+                    repos_map[item] = _repo.id
+
+            whitelist, debuginfo_whitelist = _filter_whitelist(config)
+
+            dep_map[repo.id] = _make_depsolver_item(client, repo, whitelist)
+            debuginfo_dep_map[debuginfo_repo.id] = _make_depsolver_item(
+                client, debuginfo_repo, debuginfo_whitelist
+            )
+        # run depsolver for binary repos
+        _LOG.info("Running depsolver for RPM repos: %s", list(dep_map.keys()))
+        out = _run_depsolver(list(dep_map.values()), repos_map)
+
+        # generate missing debuginfo packages
+        # TODO this seems to generate too many debuginfo packages - fix after tests with real data
+        for ubi_repo_id, pkg_list in out.items():
+            debuginfo_to_add = set()
+            for pkg in pkg_list:
+                # inspired with pungi depsolver
+                source_name = split_filename(pkg.sourcerpm)[0]
+                debuginfo_to_add.add(f"{pkg.name}-debuginfo")
+                debuginfo_to_add.add(f"{source_name}-debugsource")
+
+            _id = client.get_repository(ubi_repo_id).get_debug_repository().id
+            # update whitelist for given ubi depsolver item
+            debuginfo_dep_map[_id].whitelist.update(debuginfo_to_add)
+
+        # run depsolver for debuginfo repo
+        _LOG.info(
+            "Running depsolver for DEBUGINFO repos: %s", list(debuginfo_dep_map.keys())
+        )
+        debuginfo_out = _run_depsolver(list(debuginfo_dep_map.values()), repos_map)
+
+    out.update(debuginfo_out)
+    return out
+
+
+def _filter_whitelist(ubi_config):
+    whitelist = set()
+    debuginfo_whitelist = set()
+
+    for pkg in ubi_config.packages.whitelist:
+        if pkg.arch == "src":
+            continue
+        if pkg.name.endswith("debuginfo") or pkg.name.endswith("debugsource"):
+            debuginfo_whitelist.add(pkg.name)
+        else:
+            whitelist.add(pkg.name)
+
+    return whitelist, debuginfo_whitelist
+
+
+def _make_depsolver_item(client, repo, whitelist):
+    in_pulp_repos = _get_population_sources(client, repo)
+    return DepsolverItem(whitelist, in_pulp_repos)
+
+
+def _get_population_sources(client, repo):
+    return [client.get_repository(repo_id) for repo_id in repo.population_sources]
+
+
+def _run_depsolver(depolver_items, repos_map):
+    with Depsolver(depolver_items) as depsolver:
+        depsolver.run()
+        exported = depsolver.export()
+        out = remap_keys(repos_map, exported)
+    return out

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Set
 
 from attrs import define
 from pubtools.pulplib import YumRepository
@@ -28,8 +28,6 @@ class UbiUnit:
 
 
 @define
-class UbiRepository:
-    whitelist: List[str]
-    resolved: List[UbiUnit]
-    in_pulp_repo: YumRepository
-    out_pulp_repo: YumRepository
+class DepsolverItem:
+    whitelist: Set[str]
+    in_pulp_repos: List[YumRepository]

--- a/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
+++ b/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
@@ -1,21 +1,12 @@
 import os
 
 from more_executors.futures import f_flat_map, f_map, f_proxy, f_return, f_sequence
-from pubtools.pulplib import Client, Criteria, ModulemdUnit, RpmUnit
+from pubtools.pulplib import Criteria, ModulemdUnit, RpmUnit
 
 from .models import UbiUnit
 from .utils import flatten_list_of_sets
 
 BATCH_SIZE = int(os.getenv("UBI_MANIFEST_BATCH_SIZE", "250"))
-
-
-def make_pulp_client(config):
-    auth = None
-
-    if config.username:
-        auth = (config.username, config.password)
-
-    return Client(config.url, auth=auth, verify=not config.insecure)
 
 
 def _search_units(repo, criteria_list, content_type_cls, batch_size_override=None):

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -1,11 +1,14 @@
 import logging
 import os
-from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from itertools import chain
+from typing import List, Set
 
 from more_executors import Executors
 from more_executors.futures import f_proxy
 from pubtools.pulplib import Criteria
 
+from .models import DepsolverItem
 from .pulp_queries import search_modulemds, search_rpms
 from .utils import create_or_criteria, get_n_latest_from_content, parse_bool_deps
 
@@ -18,20 +21,26 @@ BATCH_SIZE_RESOLVER = int(os.getenv("UBI_MANIFEST_BATCH_SIZE_RESOLVER", "150"))
 
 
 class Depsolver:
-    def __init__(self, repos):
+    def __init__(self, repos: List[DepsolverItem]) -> None:
 
-        self.repos = repos
-        self.output_set = set()
+        self.repos: List[DepsolverItem] = repos
+        self.output_set: Set = set()
 
-        self._provides = set()  # set of all rpm.provides we've visited
-        self._requires = set()  # set of all rpm.requires we've visited
+        self._provides: Set = set()  # set of all rpm.provides we've visited
+        self._requires: Set = set()  # set of all rpm.requires we've visited
 
         # set of solvables (pkg, lib, ...) that we use for checking remaining requires
-        self._unsolved = set()
+        self._unsolved: Set = set()
 
-        self._modular_rpms = set()
+        self._modular_rpms: Set = set()
 
-        self._executor = Executors.thread_pool(max_workers=4)
+        self._executor: ThreadPoolExecutor = Executors.thread_pool(max_workers=4)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._executor.__exit__(*args, **kwargs)
 
     def _get_pkgs_from_all_modules(self, repos):
         # search for modulemds in all input repos
@@ -46,11 +55,11 @@ class Depsolver:
         modules = search_modulemds([Criteria.true()], repos)
         return f_proxy(self._executor.submit(extract_modular_filenames))
 
-    def get_base_packages(self, repo, pkgs_list):
+    def get_base_packages(self, repos, pkgs_list):
         crit = create_or_criteria(["name"], [(rpm,) for rpm in pkgs_list])
 
         content = f_proxy(
-            self._executor.submit(search_rpms, crit, [repo], BATCH_SIZE_RPM)
+            self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
 
         newest_rpms = get_n_latest_from_content(content, self._modular_rpms)
@@ -64,6 +73,9 @@ class Depsolver:
         _requires = set()
         for rpm in content:
             for item in rpm.requires:
+                # skip scriplet requires
+                if item.name.startswith("/"):
+                    continue
                 if item.name.startswith("("):
                     # add parsed bool deps to requires that need solving
                     _requires |= parse_bool_deps(item.name)
@@ -107,23 +119,23 @@ class Depsolver:
             C. request new content that provides remaining requirements
             D. content that provides requirements is added to self.output_set
         """
-        pulp_repos = [repo.in_pulp_repo for repo in self.repos]
+        pulp_repos = list(
+            chain.from_iterable([repo.in_pulp_repos for repo in self.repos])
+        )
         # get modular rpms first
         self._modular_rpms = self._get_pkgs_from_all_modules(pulp_repos)
 
         # search for rpms
         content_fts = [
             self._executor.submit(
-                self.get_base_packages, repo.in_pulp_repo, repo.whitelist
+                self.get_base_packages, repo.in_pulp_repos, repo.whitelist
             )
             for repo in self.repos
         ]
-
         for content in as_completed(content_fts):
             self.output_set.update(content.result())
 
         to_resolve = set(self.output_set)
-
         while True:
             # extract provides and requires
             self.extract_and_resolve(to_resolve)
@@ -150,3 +162,10 @@ class Depsolver:
             batch_size = BATCH_SIZE_RESOLVER
 
         return batch_size
+
+    def export(self):
+        out = {}
+        for item in self.output_set:
+            out.setdefault(item.associate_source_repo_id, []).append(item)
+
+        return out

--- a/ubi_manifest/worker/tasks/dummy_task.py
+++ b/ubi_manifest/worker/tasks/dummy_task.py
@@ -1,8 +1,0 @@
-from ubi_manifest.worker.tasks.celery import app
-
-
-@app.task
-def dummy_task():
-    # this was created for initial repo setup and will be removed
-    # as implementation goes on
-    return "CELERY_OK"


### PR DESCRIPTION
- added celery task that runs depsolver for given UBI repos
- this task also solves debuginfo packages
- using unittest.mock instead of mock as we can do this in py3
- renamed UbiRepository to DepsolverItem in order to express the meaning more precisely
- added simple config management for celery app
- added context manager interface to Depsolver class that will automatically shutdown executor on exit
- added type hints to various places