### PR TITLE
Apply blacklist for depsolver [RHELDST-8600]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -1,7 +1,7 @@
 import pytest
 from pubtools.pulplib import ModulemdUnit, RpmDependency, RpmUnit
 
-from ubi_manifest.worker.tasks.depsolver.models import DepsolverItem
+from ubi_manifest.worker.tasks.depsolver.models import DepsolverItem, PackageToExclude
 from ubi_manifest.worker.tasks.depsolver.rpm_depsolver import (
     BATCH_SIZE_RESOLVER,
     Depsolver,
@@ -38,7 +38,7 @@ def test_what_provides(pulp):
 
     pulp.insert_units(repo, [unit_1, unit_2])
 
-    result = depsolver.what_provides(requires, [repo])
+    result = depsolver.what_provides(requires, [repo], [])
     # there is only one unit in the result with the highest version
     assert len(result) == 1
     unit = result[0]
@@ -97,11 +97,23 @@ def test_get_base_packages(pulp):
         arch="x86_64",
     )
 
-    pulp.insert_units(repo, [unit_1, unit_2])
+    unit_3 = RpmUnit(
+        name="test-exclude",
+        version="100",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+    )
 
-    pkgs_to_search = ["test"]
+    pulp.insert_units(repo, [unit_1, unit_2, unit_3])
 
-    result = depsolver.get_base_packages([repo], pkgs_to_search)
+    pkgs_to_search = ["test", "test-exclude"]
+    blacklist = [
+        PackageToExclude("test-exc", globbing=True),
+        PackageToExclude("test", globbing=False, arch="s390x"),
+    ]
+
+    result = depsolver.get_base_packages([repo], pkgs_to_search, blacklist)
     # there should be only one package in result with the highest version
     assert len(result) == 1
     unit = result[0]
@@ -179,15 +191,24 @@ def test_run(pulp):
     """test the main method of depsolver"""
     repos, expected_output_set = _prepare_test_data(pulp)
 
+    blacklist_1 = [PackageToExclude("lib_exclude")]
+    blacklist_2 = [PackageToExclude("base_pkg_to_exclude")]
+
     whitelist_1 = ["gcc", "jq"]
     dep_item_1 = DepsolverItem(
         whitelist=whitelist_1,
+        blacklist=blacklist_1,
         in_pulp_repos=[repos[0]],
     )
 
-    whitelist_2 = ["apr", "babel"]
+    whitelist_2 = [
+        "apr",
+        "babel",
+        "base_pkg_to_exclude",
+    ]  # simulate blacklisting a package that was wrongly put into whitelist
     dep_item_2 = DepsolverItem(
         whitelist=whitelist_2,
+        blacklist=blacklist_2,
         in_pulp_repos=[repos[1]],
     )
 
@@ -210,7 +231,15 @@ def test_run(pulp):
     }
 
     # requires set holds all requires that we went through during depsolving
-    assert depsolver._requires == {"lib.a", "lib.b", "lib.c", "lib.d", "lib.e", "lib.g"}
+    assert depsolver._requires == {
+        "lib.a",
+        "lib.b",
+        "lib.c",
+        "lib.d",
+        "lib.e",
+        "lib.g",
+        "lib_exclude",
+    }
 
     # unsolved set should be empty after depsolving finishes
     # it will be emptied even if we have unsolvable dependency
@@ -218,8 +247,8 @@ def test_run(pulp):
 
     # there are unsolved requires, we can get those by
     unsolved = depsolver._requires - depsolver._provides
-    # there is exactly one unresolved dep
-    assert unsolved == {"lib.g"}
+    # there is exactly two unresolved deps, lib_exclude is unsolved due to blacklisting
+    assert unsolved == {"lib.g", "lib_exclude"}
 
     # checking correct rpm names and its associate source repo id
     output = [
@@ -285,7 +314,11 @@ def _prepare_test_data(pulp):
         epoch="1",
         arch="x86_64",
         provides=[RpmDependency(name="lib.c"), RpmDependency(name="lib.d")],
-        requires=[RpmDependency(name="lib.e"), RpmDependency(name="lib.g")],
+        requires=[
+            RpmDependency(name="lib.e"),
+            RpmDependency(name="lib.g"),
+            RpmDependency(name="lib_exclude"),
+        ],
     )
 
     unit_6 = RpmUnit(
@@ -298,11 +331,33 @@ def _prepare_test_data(pulp):
         requires=[],
     )
 
+    unit_7 = RpmUnit(
+        name="lib_exclude",
+        version="100",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        provides=[],
+        requires=[],
+    )
+
+    unit_8 = RpmUnit(
+        name="base_pkg_to_exclude",
+        version="100",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        provides=[],
+        requires=[],
+    )
+
     repo_1_units = [unit_1, unit_2, unit_5]
     repo_2_units = [unit_3, unit_4, unit_6]
 
     pulp.insert_units(repo_1, repo_1_units)
-    pulp.insert_units(repo_2, repo_2_units)
+    pulp.insert_units(
+        repo_2, repo_2_units + [unit_7, unit_8]
+    )  # add extra units, that will be excluded by blacklist
 
     expected_output_set = [(unit.name, "test_repo_1") for unit in repo_1_units] + [
         (unit.name, "test_repo_2") for unit in repo_2_units

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,7 +15,7 @@ class MockLoader:
             "modules": {},
             "packages": {
                 "include": ["package-name-.*", "gcc.*", "httpd.src", "pkg-debuginfo.*"],
-                "exclude": ["package-name-.*", "kernel"],
+                "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],
             },
             "content_sets": {
                 "rpm": {"output": "rpm_out", "input": "rpm_in"},

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -28,6 +28,14 @@ class UbiUnit:
 
 
 @define
+class PackageToExclude:
+    name: str
+    globbing: bool = False
+    arch: str = None
+
+
+@define
 class DepsolverItem:
     whitelist: Set[str]
+    blacklist: List[PackageToExclude]
     in_pulp_repos: List[YumRepository]


### PR DESCRIPTION
Now we use blacklist for excluding RPMs that shouldn't be part
of the ubi repos. Blacklist is taken from respective ubi-config file.
Blacklisting happens directly in Depsolver class, we need to apply
for all non-modular RPMs.