### PR TITLE
Introduce /manifest and /task API [RHELDST-8703] 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,10 @@
+.. _api-reference:
+
+API Reference
+=============
+
+This page is a placeholder, expected to be overwritten with openapi/api.html
+during doc build.
+
+If you are seeing this page in published docs, something has gone wrong,
+please report it!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,13 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ["_static"]
 
+# This dir contains the generated openapi spec and the static redoc-based
+# api.html for viewing. Copy it alongside the other docs.
+# Note: to enable sphinx linking to api.html, we also have an api.rst
+# and it's expected to be overwritten here. We depend on the implementation
+# detail that html_extra_path copying happens after .rst rendering.
+html_extra_path = ["openapi"]
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,19 @@
 ubi-manifest
 ===================
 
-TODO
+A microservice for generating manifest of content that should be part 
+of UBI repositories
 
-.. contents::
-  :local:
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
 
-Quick Start
+   api
+
+Overview
 -----------
 
-TODO
+ubi-mainifest is a microservice for manifest of content that should be part 
+of UBI repositories. 
+
+- For usage information on the ubi-manifest API, see :ref: `api-reference`.

--- a/docs/openapi/api.html
+++ b/docs/openapi/api.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>ubi-manifest API</title>
+
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+</head>
+
+<body>
+    <redoc spec-url='openapi.json' hide-hostname='true'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.33/bundles/redoc.standalone.js"> </script>
+</body>

--- a/scripts/gen-openapi
+++ b/scripts/gen-openapi
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Helper script to generate openapi JSON file
+# during publishing of docs.
+import json
+
+
+from ubi_manifest.app.factory import create_app
+
+api = create_app().openapi()
+
+with open("docs/openapi/openapi.json", "wt") as f:
+    json.dump(api, f)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,155 @@
+import json
+from unittest import mock
+
+from attr import define
+
+from .utils import MockedRedis
+
+
+@define
+class MockAsyncResult:
+    task_id: str
+    state: str
+
+
 def test_status(client):
     response = client.get("/api/v1/status")
 
     assert response.status_code == 200
     assert response.json() == {"status": "OK"}
+
+
+def test_task_state(client):
+    """test getting state of given celery task_id"""
+    with mock.patch("ubi_manifest.app.api.app.AsyncResult") as task_mock:
+        task_id = "some-task-id"
+        task_mock.return_value = MockAsyncResult(task_id=task_id, state="PENDING")
+
+        response = client.get(f"/api/v1/task/{task_id}")
+
+        # 200 status code is expected
+        assert response.status_code == 200
+        json_data = response.json()
+        # task_id and state are properly set in response
+        assert json_data["task_id"] == task_id
+        assert json_data["state"] == "PENDING"
+
+
+def test_task_state_not_found(client):
+    """test getting state of given celery task when task is not found"""
+    with mock.patch("ubi_manifest.app.api.app.AsyncResult") as task_mock:
+        task_id = "some-task-id"
+        task_mock.return_value = None
+
+        response = client.get(f"/api/v1/task/{task_id}")
+        # 404 is expected status code
+        assert response.status_code == 404
+        json_data = response.json()
+        # proper detail is set in the response
+        assert json_data["detail"] == f"Task {task_id} not found"
+
+
+def test_manifest_get(client):
+    """test getting depsolved content for repository"""
+    depsolver_result_item = [
+        {
+            "src_repo_id": "source-foo-bar-repo",
+            "unit_type": "RpmUnit",
+            "unit_attr": "filename",
+            "value": "some-filename.rpm",
+        },
+    ]
+
+    depsolver_result_item_json_str = json.dumps(depsolver_result_item)
+
+    redis_data = {"ubi_repo_id": depsolver_result_item_json_str}
+
+    with mock.patch("ubi_manifest.app.api.redis.from_url") as mock_redis_from_url:
+        mock_redis_from_url.return_value = MockedRedis(data=redis_data)
+        response = client.get(f"/api/v1/manifest/ubi_repo_id")
+
+        # expected status code in 200
+        assert response.status_code == 200
+        json_data = response.json()
+        # repo_id is set to the one we requested
+        assert json_data["repo_id"] == "ubi_repo_id"
+
+        content = json_data["content"]
+        # there is only one unit in the content
+        assert len(content) == 1
+        content_item = content[0]
+        # details of unit are set properly
+        assert content_item["src_repo_id"] == "source-foo-bar-repo"
+        assert content_item["unit_type"] == "RpmUnit"
+        assert content_item["unit_attr"] == "filename"
+        assert content_item["value"] == "some-filename.rpm"
+
+
+def test_manifest_get_not_found(client):
+    """test getting depsolved content when the cotent is not available for given repo_id"""
+    with mock.patch("ubi_manifest.app.api.redis.from_url") as mock_redis_from_url:
+        mock_redis_from_url.return_value = MockedRedis(data={})
+        response = client.get("/api/v1/manifest/ubi_repo_id")
+        # expected status code is 404
+        assert response.status_code == 404
+        json_data = response.json()
+        # response detail is properly set
+        assert json_data["detail"] == "Content for ubi_repo_id not found"
+
+
+def test_manifest_post(client):
+    """test request for depsolving for given repo ids"""
+    with mock.patch("celery.app.task.Task.apply_async") as mocked_apply_async:
+        mocked_apply_async.return_value = MockAsyncResult(
+            task_id="foo-bar-id", state="PENDING"
+        )
+
+        # will request depsolving for 2 repos
+        # 'repo_1' is set in the default config, and it will be depsolving
+        # 'repo_not_allowed' will be skipped - not present in the config
+        response = client.post(
+            "/api/v1/manifest", json={"repo_ids": ["repo_1", "repo_not_allowed"]}
+        )
+
+        # depsolve task is run with 2 repos in args:
+        # 'repo_1' was requested via API
+        # 'repo_2' is taken from repo_group that is defined in the config
+        # it's required to run depsolving for whole repo_group, otherwise we
+        # won't be able to find some deps that are not in the 'repo_1' but are
+        # present in 'repo_2'
+        # 'repo_not_allowed' is skipped completely
+        mocked_apply_async.assert_called_once_with(
+            args=[
+                ["repo_1", "repo_2"],
+            ]
+        )
+
+        # expected status code is 200
+        assert response.status_code == 201
+        json_data = response.json()
+        # one task is expected to be spawned therefore there is only one item
+        # in the response with proper task_id and state set
+        assert len(json_data) == 1
+        item = json_data[0]
+        assert item["task_id"] == "foo-bar-id"
+        assert item["state"] == "PENDING"
+
+
+def test_manifest_post_not_allowed(client):
+    """test request for depsolving for given repo ids, but none of the is allowed by config"""
+    with mock.patch("celery.app.task.Task.apply_async") as mocked_apply_async:
+        # none of repos in request are allowed for depsolving by config
+        response = client.post(
+            "/api/v1/manifest",
+            json={"repo_ids": ["repo_not_allowed_1", "repo_not_allowed_2"]},
+        )
+        # we never call apply_async on depsolve_task
+        mocked_apply_async.assert_not_called()
+        # expected status code is 404
+        assert response.status_code == 404
+        # there is enough detail info in the response
+        json_data = response.json()
+        assert (
+            json_data["detail"]
+            == "None of ['repo_not_allowed_1', 'repo_not_allowed_2'] are allowed for depsolving."
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,7 @@
+from typing import List
+
 import ubiconfig
+from attrs import define
 from pubtools.pulplib import YumRepository
 
 
@@ -26,3 +29,17 @@ class MockLoader:
         }
 
         return [ubiconfig.UbiConfig.load_from_dict(config_raw, "foo", "8")]
+
+
+@define
+class MockedRedis:
+    data: dict
+
+    def set(self, key: str, value: str, **kwargs) -> None:
+        self.data[key] = value
+
+    def get(self, key: str) -> str:
+        return self.data.get(key)
+
+    def keys(self) -> List[str]:
+        return list(self.data.keys())

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps=
 	alabaster
 use_develop=true
 commands=
+	python scripts/gen-openapi
 	sphinx-build -M html docs docs/_build -W
 
 [pytest]

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -1,4 +1,13 @@
-from fastapi import APIRouter
+import json
+from typing import List
+
+import redis
+from fastapi import APIRouter, HTTPException
+
+from ubi_manifest.worker.tasks.celery import app
+from ubi_manifest.worker.tasks.depsolve import depsolve_task
+
+from .models import DepsolveItem, DepsolverResult, DepsolverResultItem, TaskState
 
 router = APIRouter(prefix="/api/v1")
 
@@ -6,3 +15,136 @@ router = APIRouter(prefix="/api/v1")
 @router.get("/status")
 async def status():
     return {"status": "OK"}
+
+
+@router.post(
+    "/manifest",
+    response_model=List[TaskState],
+    status_code=201,
+    responses={
+        201: {
+            "description": "Depsolve tasks created",
+            "content": {
+                "application/json": {
+                    "example": [
+                        {
+                            "task_id": "some_task_id",
+                            "state": "PENDING",
+                        }
+                    ]
+                }
+            },
+        },
+        404: {
+            "description": "None of repositories requested are not allowed for depsolving.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "details": "None of [repo_id] are allowed for depsolving."
+                    }
+                }
+            },
+        },
+    },
+)
+async def manifest_post(depsolve_item: DepsolveItem) -> List[TaskState]:
+    repo_groups = {}
+    # compare provided repo_ids with the config and pick allowed repo groups
+    for repo_id in depsolve_item.repo_ids:
+        for key, group in app.conf.allowed_ubi_repo_groups.items():
+            if repo_id in group:
+                repo_groups.setdefault(key, group)
+
+    if not repo_groups:
+        raise HTTPException(
+            status_code=404,
+            detail=f"None of {depsolve_item.repo_ids} are allowed for depsolving.",
+        )
+
+    tasks_states = []
+    for repo_group in repo_groups.values():
+        task = depsolve_task.apply_async(args=[repo_group])
+        tasks_states.append(TaskState(task_id=task.task_id, state=task.state))
+
+    return tasks_states
+
+
+@router.get(
+    "/manifest/{repo_id}",
+    response_model=DepsolverResult,
+    status_code=200,
+    responses={
+        200: {
+            "description": "Depsolved content for repo_id found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "repo_id": "foo-bar-repo",
+                        "content": [
+                            {
+                                "src_repo_id": "source-foo-bar-repo",
+                                "unit_type": "RpmUnit",
+                                "unit_attr": "filename",
+                                "value": "some-filename.rpm",
+                            }
+                        ],
+                    }
+                }
+            },
+        },
+        404: {
+            "description": "Content for request repository is not available.",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Content for foo-repo not found"}
+                }
+            },
+        },
+    },
+)
+async def manifest_get(repo_id: str) -> DepsolverResult:
+    redis_client = redis.from_url(app.conf.backend)
+    value = redis_client.get(repo_id) or ""
+    if value:
+        content = []
+        for value in json.loads(value):
+            item = DepsolverResultItem(**value)
+            content.append(item)
+        result = DepsolverResult(repo_id=repo_id, content=[item])
+        return result
+
+    raise HTTPException(status_code=404, detail=f"Content for {repo_id} not found")
+
+
+@router.get(
+    "/task/{task_id}",
+    response_model=TaskState,
+    status_code=200,
+    responses={
+        200: {
+            "description": "Task with task_id found",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "task_id": "some-task-id",
+                        "state": "PENDING",
+                    }
+                }
+            },
+        },
+        404: {
+            "description": "Task with task_id not found",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "Task some-other-task-id not found"}
+                }
+            },
+        },
+    },
+)
+async def task_state(task_id: str) -> TaskState:
+    task = app.AsyncResult(task_id)
+    if task:
+        return TaskState(task_id=task.task_id, state=task.state)
+
+    raise HTTPException(status_code=404, detail=f"Task {task_id} not found")

--- a/ubi_manifest/app/models.py
+++ b/ubi_manifest/app/models.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from pydantic import BaseModel  # pylint: disable=no-name-in-module
+
+
+class DepsolveItem(BaseModel):
+    repo_ids: List[str]
+
+
+class TaskState(BaseModel):
+    task_id: str
+    state: str
+
+
+class DepsolverResultItem(BaseModel):
+    src_repo_id: str
+    unit_type: str
+    unit_attr: str
+    value: str
+
+
+class DepsolverResult(BaseModel):
+    repo_id: str
+    content: List[DepsolverResultItem]

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -12,10 +12,13 @@ class Config:
     pulp_password: str = "pass"
     pulp_insecure: bool = False
     ubi_config_url: str = "some_url"
-    allowed_ubi_repos: dict = None
-    include: List[str] = ["ubi_manifest.worker.tasks.depsolve_task"]
-    broker: str = "redis://localhost:6379/0"
+    allowed_ubi_repo_groups: dict = {("group1", "some_arch"): ["repo_1", "repo_2"]}
+    imports: List[str] = ["ubi_manifest.worker.tasks.depsolve"]
+    broker_url: str = "redis://localhost:6379/0"
     backend: str = "redis://localhost:6379/0"
+    ubi_manifest_data_expiration: int = (
+        60 * 60 * 4
+    )  # 4 hours default data expiration for redis
 
 
 def make_config(celery_app):
@@ -23,6 +26,8 @@ def make_config(celery_app):
     config_from_file = configparser.ConfigParser()
     config_from_file.read(config_file)
     try:
+        # TODO allowed_ubi_repo_groups item needs parsing as
+        # it's expected to be a json string in the config file
         config = Config(**dict(config_from_file["CONFIG"]))
     except KeyError:
         config = Config()

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -19,6 +19,9 @@ class UbiUnit:
     def __str__(self):
         return str(self._unit)
 
+    def isinstance_inner_unit(self, klass):
+        return isinstance(self._unit, klass)
+
     # TODO make this return hash of self._unit if possible in future
     # it should help us with not adding the same units into sets
     # that differ with associate_source_repo_id attr only

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -108,6 +108,9 @@ class Depsolver:
         """
         Get the latest rpms that provides requirements from list_of_requires in given repos
         """
+        # TODO this may pull more than more packages (with different names)
+        # for given requirement. It should be decided which one should get into
+        # the output. Currently we'll get all matching the query.
         crit = create_or_criteria(
             ["provides.name"], [(item,) for item in list_of_requires]
         )
@@ -139,6 +142,7 @@ class Depsolver:
             B. set internal state of self accordingly to the content acquired
             C. request new content that provides remaining requirements
             D. content that provides requirements is added to self.output_set
+        3. During phase 1. and 2. source RPM packages are queried for already acquired RPMS.
         """
         pulp_repos = list(
             chain.from_iterable([repo.in_pulp_repos for repo in self.repos])


### PR DESCRIPTION
This commit introduced a couple of endpoints for ubi-manifest service:

- /manifest (POST): covers [RHELDST-8703] with a slight modification
  - exact ids of UBI repositories are expected in the request body.
  This endpoint allows to enqueue tasks that will perform depsolving f
  for requested repositories.
  Repositories are filtered by configration item 'allowed_ubi_repo_groups'
  that defines 'repo_groups'. Repositories in one group have to be
  depsolved at once, as units from each repository in a group are
  required to do full depsolving.
  This endpoint return list of tasks that were enqueued.
  'allowed_ubi_repo_groups' functionality covers [RHELDST-8602]

- /manifest/{repo_id} (GET): covers part of [RHELDST-8705] with
  a slight modification of output format.
  This endpoint returns UBI manifest for specific repository in given format
  if manifest is available.

- /task/{task_id} (GET): covers part of [RHELDST-8705].
  This endpoint returns state of requested task_id if the task
  with this id exists.

Another set of changes/additions:
* Depsolve task result:
  - the result is now stored in redis where
    key of destination repository id, value is a json string that
    encodes list of content units that should appear in a repository
    in a specific format.
  - Result is set to redis with expiration date of the data. This also
    solves the 'caching' requirement. Expiration time is can be modified
    via config.
  - Removed TODO in test_depsolve_task - as the task returns None now.
* Added openapi docs generation.
* Fixed/improved default config
* Added also a couple of TODOs that may be worth fixing later.