### PR TITLE
API: Added delete method for /manifest endpoint [RHELDST-8704]

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -118,13 +118,13 @@ def test_depsolve_task(pulp):
 
                 # there should 3 keys stored in redis
                 assert sorted(redis.keys()) == [
-                    "ubi_debug_repo",
-                    "ubi_repo",
-                    "ubi_source_repo",
+                    "manifest:ubi_debug_repo",
+                    "manifest:ubi_repo",
+                    "manifest:ubi_source_repo",
                 ]
 
                 # load json string stored in redis
-                data = redis.get("ubi_repo")
+                data = redis.get("manifest:ubi_repo")
                 content = json.loads(data)
                 # binary repo contains only one rpm
                 assert len(content) == 1
@@ -135,7 +135,7 @@ def test_depsolve_task(pulp):
                 assert unit["value"] == "gcc-10.200.x86_64.rpm"
 
                 # load json string stored in redis
-                data = redis.get("ubi_debug_repo")
+                data = redis.get("manifest:ubi_debug_repo")
                 content = sorted(json.loads(data), key=lambda d: d["value"])
                 # debuginfo repo conains two debug packages
                 assert len(content) == 2
@@ -152,7 +152,7 @@ def test_depsolve_task(pulp):
                 assert unit["value"] == "gcc_src-debugsource-10.200.x86_64.rpm"
 
                 # load json string stored in redis
-                data = redis.get("ubi_source_repo")
+                data = redis.get("manifest:ubi_source_repo")
                 content = json.loads(data)
                 # source repo contain one SRPM package
                 assert len(content) == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,3 +43,7 @@ class MockedRedis:
 
     def keys(self) -> List[str]:
         return list(self.data.keys())
+
+    def delete(self, key: str) -> None:
+        if key in self.data:
+            del self.data[key]

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -129,7 +129,9 @@ def _save(data: Dict[str, List[UbiUnit]]) -> None:
     # save data to redis as key:json_string
     for key, values in data_for_redis.items():
         redis_client.set(
-            key, json.dumps(values), ex=app.conf["ubi_manifest_data_expiration"]
+            f"manifest:{key}",
+            json.dumps(values),
+            ex=app.conf["ubi_manifest_data_expiration"],
         )
 
 


### PR DESCRIPTION
API endpoint /manifest/{repo_id} now support DELETE method that
will remove entry in the Redis storage.

Naming of keys for manifest entries were modified to safer
varinat. Now the manifest is saved with key in the form:
"manifest:<REPO_ID>": value.