### PR TITLE
Fix pages handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals=sh
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==21.12b0
+	black==22.3.0
 	pylint==2.12.2
 commands=
 	black --check .

--- a/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
+++ b/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
@@ -20,7 +20,7 @@ def _search_units(repo, criteria_list, content_type_cls, batch_size_override=Non
         for unit in page.data:
             unit = UbiUnit(unit, repo.id)
             units.add(unit)
-        if page.next:
+        if page.next and page.next.result():
             return f_flat_map(page.next, handle_results)
         return f_return(units)
 


### PR DESCRIPTION
Previously implemented handling of data pages coming
from pulp resulted in:
`Cancel next page due to GC: True`
whenever page.next was processed.

This now has been mitigated and should work as intended
and all pages are properly processed.
The solution is possibly not optimal as it adds blocking
while we wait for next page.

Unrelated addtion:
* bump version of black because of
`ImportError: cannot import name '_unicodefun' from 'click'`