### PR TITLE
Fix SRPM handling [RHELDST-8703]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals=sh
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==21.12b0
+	black==22.3.0
 	pylint==2.12.2
 commands=
 	black --check .

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -106,7 +106,16 @@ def depsolve_task(ubi_repo_ids: List[str]) -> None:
             list(debuginfo_dep_map.values()), repos_map, in_source_rpm_repos
         )
 
-    out.update(debuginfo_out)
+    # merge 'out' and 'debuginfo_out' dicts without overwriting any entry
+    for key, data in debuginfo_out.items():
+        if key in out:
+            filenames = [item.filename for item in out[key]]
+            for item in data:
+                if item.filename not in filenames:
+                    out[key].append(item)
+        else:
+            out[key] = data
+
     # save depsolved data to redis
     _save(out)
 


### PR DESCRIPTION
- usually SRPM is shared with more than one binary or debug RPM, this
  change deduplicates the SRPM output set in order tho have only unique
  entries there.
- previously depsolve() task merged two output dictionaries of binary
  and debuginfo depsolver, but using dict.update() overwrote some entries
  in the output dict. Now we merge dictionaries in a save way - values on each
  key are merged as well, not overwritten. This happened only with SRPM
  repos as debuginfo packages share the same SRPMs with binary RPMs.