### PR TITLE
Add modulemd depsolver [RHELDST-8601]

### DIFF
--- a/tests/test_modulemd_depsolver.py
+++ b/tests/test_modulemd_depsolver.py
@@ -1,0 +1,271 @@
+import pytest
+from pubtools.pulplib import ModulemdDependency, ModulemdUnit, RpmUnit
+from ubiconfig.config_types.modules import Module
+
+from ubi_manifest.worker.tasks.depsolver.models import (
+    ModularDepsolverItem,
+    PackageToExclude,
+    UbiUnit,
+)
+from ubi_manifest.worker.tasks.depsolver.modulemd_depsolver import ModularDepsolver
+
+from .utils import create_and_insert_repo
+
+
+def test_export(modular_depsolver):
+    """Test exporting from ModularDepsolver"""
+
+    # Define mock UbiUnits
+    module1 = ModulemdUnit(
+        name="perl-YAML",
+        stream="1.24",
+        version=8030020200313080146,
+        context="b7fad3bf",
+        arch="x86_64",
+    )
+    unit1 = UbiUnit(module1, "test_repo1")
+
+    module2 = ModulemdUnit(
+        name="perl",
+        stream="5.30",
+        version=8040020200923213406,
+        context="466ea64f",
+        arch="x86_64",
+    )
+    unit2 = UbiUnit(module2, "test_repo1")
+
+    module3 = ModulemdUnit(
+        name="perl",
+        stream="6.30",
+        version=3,
+        context="ABC",
+        arch="x86_64",
+    )
+    unit3 = UbiUnit(module3, "test_repo2")
+
+    # this is copy of module3 to test that duplicates are skipped
+    module4 = ModulemdUnit(
+        name="perl",
+        stream="6.30",
+        version=3,
+        context="ABC",
+        arch="x86_64",
+    )
+    unit4 = UbiUnit(module4, "test_repo2")
+
+    expected_out = {}
+    expected_out["modules"] = {"test_repo1": [unit1, unit2], "test_repo2": [unit3]}
+
+    modular_depsolver.modules = [unit1, unit2, unit3, unit4]
+    dep_out = modular_depsolver.export()
+
+    assert expected_out == dep_out
+
+
+def test_run(pulp):
+    """Test the main method of ModularDepsolver."""
+
+    repos, expected_output_modules = _prepare_pulp(pulp)
+
+    modulelist1 = [Module("perl-YAML", "1.24")]
+    in_pulp_repos1 = [repos[0]]
+    mod_dep_item1 = ModularDepsolverItem(modulelist1, repos[0], in_pulp_repos1)
+
+    modulelist2 = [Module("module_in_second_repo", "8.30")]
+    in_pulp_repos2 = [repos[1]]
+    mod_dep_item2 = ModularDepsolverItem(modulelist2, repos[1], in_pulp_repos2)
+
+    with ModularDepsolver([mod_dep_item1, mod_dep_item2]) as depsolver:
+        depsolver.run()
+
+        # all the modules should be searched
+        assert depsolver._searched_modules["with_stream"] == set(
+            f"{x[0]}:{x[1]}"
+            for x in expected_output_modules
+            if not x[0] == "test_none_in_stream"
+        )
+        assert depsolver._searched_modules["without_stream"] == set(
+            f"{x[0]}" for x in expected_output_modules if x[0] == "test_none_in_stream"
+        )
+
+        assert len(depsolver.modules) == len(expected_output_modules)
+
+        output_modules = list(
+            (x.name, x.stream, x.associate_source_repo_id) for x in depsolver.modules
+        )
+        output_modules.sort(key=lambda x: (x[0], x[1]))
+        assert output_modules == expected_output_modules
+
+
+def _prepare_pulp(pulp):
+
+    # Define mock repos
+    repo_1 = create_and_insert_repo(id="test_repo_1", pulp=pulp)
+
+    repo_2 = create_and_insert_repo(id="test_repo_2", pulp=pulp)
+
+    # Define mock module units for repo_1
+    module1 = ModulemdUnit(
+        name="perl-YAML",
+        stream="1.24",
+        version=8030020200313080146,
+        context="b7fad3bf",
+        arch="x86_64",
+        artifacts=[
+            "perl-YAML-0:1.24-3.module+el8.1.0+2934+dec45db7.noarch",
+            "perl-YAML-0:1.24-3.module+el8.1.0+2934+dec45db7.src",
+        ],
+        dependencies=[
+            ModulemdDependency(name="perl", stream="5.30"),
+            ModulemdDependency(name="dependency_1", stream="11.1"),
+        ],
+    )
+
+    module2 = ModulemdUnit(
+        name="perl",
+        stream="5.30",
+        version=8040020200923213406,
+        context="466ea64f",
+        arch="x86_64",
+        artifacts=[
+            "perl-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "perl-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "perl-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "perl-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+        dependencies=[
+            ModulemdDependency(name="dependency_2", stream="2.22"),
+            ModulemdDependency(name="dependency_1", stream="11.1"),
+        ],
+    )
+
+    ignored_module = ModulemdUnit(
+        name="ignored",
+        stream="6.30",
+        version=3,
+        context="ABC",
+        arch="x86_64",
+        artifacts=[
+            "ignored-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "ignored-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    module_dep_1 = ModulemdUnit(
+        name="dependency_1",
+        stream="11.1",
+        version=1,
+        context="def",
+        arch="x86_64",
+        artifacts=[
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "dep1-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "dep1-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    module_dep_2 = ModulemdUnit(
+        name="dependency_2",
+        stream="2.22",
+        version=2,
+        context="efg",
+        arch="x86_64",
+        artifacts=[
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "dep1-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "dep1-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    repo_1_units = [module1, module2, module_dep_1, module_dep_2, ignored_module]
+    pulp.insert_units(repo_1, repo_1_units)
+
+    # Define mock module units for repo_2
+    module4 = ModulemdUnit(
+        name="module_in_second_repo",
+        stream="8.30",
+        version=6,
+        context="fgh",
+        arch="x86_64",
+        artifacts=[
+            "secondRepoRPM-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "secondRepoRPM-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+        ],
+        dependencies=[
+            ModulemdDependency(
+                name="dependency_2", stream="something completely different"
+            ),
+            ModulemdDependency(name="test_none_in_stream", stream=None),
+            ModulemdDependency(name="dependency_1", stream="11.1"),
+        ],
+    )
+
+    module_dep_3 = ModulemdUnit(
+        name="dependency_2",
+        stream="something completely different",
+        version=3,
+        context="efg",
+        arch="x86_64",
+        artifacts=[
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "dep1-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "dep1-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "dep1-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    module_dep_4 = ModulemdUnit(
+        name="test_none_in_stream",
+        stream="v1",
+        version=3,
+        context="efg",
+        arch="x86_64",
+        artifacts=[
+            "dep3-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "dep3-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "dep3-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "dep3-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    module_dep_5 = ModulemdUnit(
+        name="test_none_in_stream",
+        stream="v2",
+        version=3,
+        context="efg",
+        arch="x86_64",
+        artifacts=[
+            "dep3-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
+            "dep3-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
+            "dep3-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
+            "dep3-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
+        ],
+    )
+
+    repo_2_units = [module4, module_dep_3, module_dep_4, module_dep_5]
+    pulp.insert_units(repo_2, repo_2_units)
+
+    expected_output_set = list(
+        [
+            (module.name, module.stream, repo_1.id)
+            for module in repo_1_units
+            if not module.name == "ignored"
+        ]
+        + [(module.name, module.stream, repo_2.id) for module in repo_2_units]
+    )
+    expected_output_set.sort(key=lambda x: (x[0], x[1]))
+    return [repo_1, repo_2], expected_output_set
+
+
+@pytest.fixture
+def modular_depsolver(pulp):
+    """Returns simple ModularDepsolver instance"""
+    # Prepare modular depsolver item
+    repo = create_and_insert_repo(id="test_repo", pulp=pulp)
+    modulelist = [Module("perl-YAML", "1.24")]
+    in_pulp_repos = [repo]
+    mod_dep_item = ModularDepsolverItem(modulelist, repo, in_pulp_repos)
+
+    return ModularDepsolver([mod_dep_item])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,7 +15,14 @@ def create_and_insert_repo(**kwargs):
 class MockLoader:
     def load_all(self):
         config_raw = {
-            "modules": {},
+            "modules": {
+                "include": [
+                    {
+                        "name": "fake_name",
+                        "stream": "fake_stream",
+                    }
+                ]
+            },
             "packages": {
                 "include": ["package-name-.*", "gcc.*", "httpd.src", "pkg-debuginfo.*"],
                 "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -2,6 +2,7 @@ from typing import List, Set
 
 from attrs import define
 from pubtools.pulplib import YumRepository
+from ubiconfig.config_types.modules import Module
 
 
 class UbiUnit:
@@ -41,4 +42,11 @@ class PackageToExclude:
 class DepsolverItem:
     whitelist: Set[str]
     blacklist: List[PackageToExclude]
+    in_pulp_repos: List[YumRepository]
+
+
+@define
+class ModularDepsolverItem:
+    modulelist: List[Module]
+    repo: YumRepository
     in_pulp_repos: List[YumRepository]

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -1,0 +1,125 @@
+"""
+Module for depsolving modulemds in ubi repositories
+"""
+import logging
+import os
+from itertools import chain
+from typing import Dict, List, Set
+
+from more_executors import Executors
+from more_executors.futures import f_proxy
+from pubtools.pulplib import YumRepository
+
+from .models import ModularDepsolverItem, UbiUnit
+from .pulp_queries import search_modulemds
+from .utils import get_criteria_for_modules, get_modulemd_output_set
+
+_LOG = logging.getLogger(__name__)
+
+MAX_WORKERS = int(os.getenv("UBI_MANIFEST_MODULAR_DEPSOLVER_WORKERS", "8"))
+
+
+class ModularDepsolver:
+    """
+    Class for depsolving modulemd units
+    """
+
+    def __init__(self, modular_items: List[ModularDepsolverItem]) -> None:
+        self._modular_items: List[ModularDepsolverItem] = modular_items
+        self._input_repos: List[YumRepository] = list(
+            chain.from_iterable(item.in_pulp_repos for item in self._modular_items)
+        )
+        # executor for this class, not adding retries because for pulp
+        # we use executor from pulplib
+        self._executor = Executors.thread_pool(
+            max_workers=MAX_WORKERS, name="modular-depsolver"
+        )
+
+        # set of all already searched modules to avoid duplication & cycles
+        self._searched_modules: Dict[str, Set[str]] = {
+            "without_stream": set(),
+            "with_stream": set(),
+        }
+        # output set of resolved modulemd packages
+        self.modules: List[UbiUnit] = []
+
+    def __enter__(self):
+        self._executor.__enter__()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._executor.__exit__(*args, **kwargs)
+
+    def run(self):
+        """
+        Run depsolver for each moudular dependency - recursively resolve all of
+        its modular dependencies and add binary and debug dependencies to list.
+        """
+        for item in self._modular_items:
+            modulemds_criteria = get_criteria_for_modules(item.modulelist)
+            for module in item.modulelist:
+                self._update_searched_modules(module)
+            modules = f_proxy(
+                self._executor.submit(
+                    search_modulemds, modulemds_criteria, item.in_pulp_repos
+                )
+            )
+            # recurrently resolve dependencies for found modules
+            self._depsolve_modules(modules)
+
+    def _depsolve_modules(self, modules):
+        """
+        Update modulemd output set with latest versions of modules, then find
+        dependencies for the modules and depsolve them.
+        """
+        filtered_modules = get_modulemd_output_set(modules)
+        self.modules.extend(filtered_modules)
+
+        modules_to_search = []
+        for module in filtered_modules:
+            # If dependencies is None, skip it
+            if not module.dependencies:
+                continue
+            # Get all unresolved dependencies
+            for dependency in module.dependencies:
+                if not self._already_searched(dependency):
+                    modules_to_search.append(dependency)
+                    self._update_searched_modules(dependency)
+
+        # If there are some unresolved dependencies, get them and depsolve them recursively
+        if modules_to_search:
+            modulemds_criteria = get_criteria_for_modules(modules_to_search)
+            new_modules = f_proxy(
+                self._executor.submit(
+                    search_modulemds, modulemds_criteria, self._input_repos
+                )
+            )
+            self._depsolve_modules(new_modules)
+
+    def _update_searched_modules(self, module):
+        if module.stream is None:
+            self._searched_modules["without_stream"].add(module.name)
+        else:
+            self._searched_modules["with_stream"].add(f"{module.name}:{module.stream}")
+
+    def _already_searched(self, module):
+        """Returns True if the module has not yet been searched for"""
+        return (
+            module.name in self._searched_modules["without_stream"]
+            or f"{module.name}:{module.stream}" in self._searched_modules["with_stream"]
+        )
+
+    def export(self) -> Dict[str, Dict[str, List[UbiUnit]]]:
+        """Returns a dictionary of depsolved modules."""
+        out = {}
+        modules_out = {}
+        nsvca_set = set()
+        for module in self.modules:
+            # filter duplicates
+            if not module.nsvca in nsvca_set:
+                nsvca_set.add(module.nsvca)
+                modules_out.setdefault(module.associate_source_repo_id, []).append(
+                    module
+                )
+        out["modules"] = modules_out
+        return out


### PR DESCRIPTION
Add a modulemd depsolver module. In the module we resolve the modulemd
dependencies of ubi repositories.
- For each modulemd dependency (for each package and stream) we get the
  most recent versions of packages.
- We recursively depsolve all the modulemd dependencies of the packages
  from previos step

The modulemd depsolver currently resolves only the modulemd
dependencies. The depsolving of modulemd defaults and RPM packages will
be added in later commits.