### PR TITLE
Add source rpm depsolving for modulemds [RHELDST-8601]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -212,11 +212,12 @@ def test_run(pulp):
         in_pulp_repos=[repos[1]],
     )
 
-    modules = {
+    module_rpms = {
         "perl-version-1.99.24-441.module+el8.4.0+9911+7f269185.x86_64.rpm",
+        "yaml-version-0.99.24-441.module+el8.4.0+9911+7f269185.src.rpm",
     }
 
-    with Depsolver([dep_item_1, dep_item_2], [repo_srpm], modules) as depsolver:
+    with Depsolver([dep_item_1, dep_item_2], [repo_srpm], module_rpms) as depsolver:
         depsolver.run()
 
         # check internal state of depsolver object
@@ -432,9 +433,21 @@ def _prepare_test_data(pulp):
         requires=[],
     )
 
+    unit_13 = RpmUnit(
+        name="yaml",
+        filename="yaml-version-0.99.24-441.module+el8.4.0+9911+7f269185.src.rpm",
+        version="000",
+        release="099",
+        epoch="1",
+        arch="x86_64",
+        provides=[],
+        requires=[],
+        content_type_id="srpm",
+    )
+
     repo_1_units = [unit_1, unit_2, unit_5, unit_11, unit_12]
     repo_2_units = [unit_3, unit_4, unit_6]
-    repo_srpm_units = [unit_9, unit_10]
+    repo_srpm_units = [unit_9, unit_10, unit_13]
 
     pulp.insert_units(repo_1, repo_1_units + [md_unit_1, md_unit_2])
     pulp.insert_units(

--- a/tests/test_modulemd_depsolver.py
+++ b/tests/test_modulemd_depsolver.py
@@ -81,10 +81,9 @@ def test_export(modular_depsolver):
     rpm_units = {
         "perl-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
         "perl-4:5.30.1-452.module+el8.4.0+8990+01326e37.x86_64",
-        "perl-archive-tar-0:2.32-440.module+el8.3.0+6718+7f269185.src",
         "perl-archive-zip-0:1.67-1.module+el8.3.0+6718+7f269185.noarch",
         "nodejs-debuginfo-1:10.24.0-1.module+el8.3.0+10166+b07ac28e.x86_64",
-        "nodejs-debugsource-1:10.24.0-1.module+el8.3.0+10166+b07ac28e.x86_64",
+        "perl-4:5.30.1-452.module+el8.4.0+8990+01326e37.src",
     }
 
     expected_out = {}
@@ -383,7 +382,7 @@ def _prepare_pulp(pulp):
     # Filter out .src modular rpms
     expected_modular_rpms = set(
         filter(
-            lambda x: not x.endswith(".src.rpm") and not "not-in-profile" in x,
+            lambda x: not "not-in-profile" in x,
             modular_rpms,
         )
     )

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -101,7 +101,10 @@ def depsolve_task(ubi_repo_ids: List[str]) -> None:
         # could be moved to the Depsolver. It should lead to more async processing
         # and better performance
         rpm_out = _run_depsolver(
-            list(dep_map.values()), repos_map, in_source_rpm_repos, modulemd_rpm_deps
+            list(dep_map.values()),
+            repos_map,
+            in_source_rpm_repos,
+            modulemd_rpm_deps,
         )
 
         _merge_output_dictionary(out, rpm_out)

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -145,9 +145,6 @@ class ModularDepsolver:
                     pkg_names.extend(module.profiles.get(profile) or [])
 
             for pkg in module.artifacts_filenames:
-                # Filter out source packages
-                if pkg.endswith(".src.rpm"):
-                    continue
                 # filter by profile if available
                 if pkg_names:
                     name, _, _, _, _ = split_filename(pkg)

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -271,7 +271,12 @@ class Depsolver:
 
     def export(self):
         out = {}
+        # set of unique filenames
+        filenames = set()
         for item in self.output_set | self.srpm_output_set:
-            out.setdefault(item.associate_source_repo_id, []).append(item)
+            # deduplicate output sets
+            if item.filename not in filenames:
+                filenames.add(item.filename)
+                out.setdefault(item.associate_source_repo_id, []).append(item)
 
         return out


### PR DESCRIPTION
Since modulemd units can also depend on source rpms, we have added a
capability to resolve the source rpm dependencies of modulemds.