### PR TITLE
Fix docs building

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
The option languange=None is no longer valid, building docs failed with:
"Invalid configuration value found: 'language = None'. Update your
configuration to a valid langauge code. Falling back to 'en' (English)."

Let's use "en" to overcome this issue.