### PR TITLE
Improve pulp queries with unit_fields limit [RHELDST-12136]

### DIFF
--- a/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
+++ b/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
@@ -8,6 +8,24 @@ from .utils import flatten_list_of_sets
 
 BATCH_SIZE = int(os.getenv("UBI_MANIFEST_BATCH_SIZE", "250"))
 
+RPM_FIELDS = ["name", "filename", "sourcerpm", "requires", "provides"]
+MODULEMD_FIELDS = [
+    "name",
+    "stream",
+    "version",
+    "context",
+    "arch",
+    "dependencies",
+    "profiles",
+    "artifacts",
+]
+
+UNIT_FIELDS = {
+    RpmUnit: RPM_FIELDS,
+    ModulemdUnit: MODULEMD_FIELDS,
+    # using fields limit to query doesn't work for modulemd_defaults unit
+}
+
 
 def _search_units(repo, criteria_list, content_type_cls, batch_size_override=None):
     """
@@ -15,6 +33,7 @@ def _search_units(repo, criteria_list, content_type_cls, batch_size_override=Non
     """
     units = set()
     batch_size = batch_size_override or BATCH_SIZE
+    unit_fields = UNIT_FIELDS.get(content_type_cls, None)
 
     def handle_results(page):
         for unit in page.data:
@@ -32,7 +51,7 @@ def _search_units(repo, criteria_list, content_type_cls, batch_size_override=Non
 
     for criteria_batch in criteria_split:
         _criteria = Criteria.and_(
-            Criteria.with_unit_type(content_type_cls),
+            Criteria.with_unit_type(content_type_cls, unit_fields=unit_fields),
             Criteria.or_(*criteria_batch),
         )
 


### PR DESCRIPTION
Previously we queried pulp without limit to unit fields. This may lead
to requesting extremely large amount of data from pulp we don't need.
Large queries were very likely to cause 500 error on pulp server
or hit RemoteDisconnected error and it required more RAM on ubi-manifest
and pulp sides. Also some queries took several minutes to finish
and caused performance drop when they were re-tried multiple times.

With this fix we limit unit fields to those we really need while
getting better or more stable performance.