### PR TITLE
Do not skip non-modular RPMs in the RPM depsolver [RHELDST-12137]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -194,7 +194,7 @@ def test_run(pulp):
     blacklist_1 = [PackageToExclude("lib_exclude")]
     blacklist_2 = [PackageToExclude("base_pkg_to_exclude")]
 
-    whitelist_1 = ["gcc", "jq"]
+    whitelist_1 = ["gcc", "jq", "perl-version"]
     dep_item_1 = DepsolverItem(
         whitelist=whitelist_1,
         blacklist=blacklist_1,
@@ -413,7 +413,7 @@ def _prepare_test_data(pulp):
     # unit_11a/b are modular units, both of them has to be added to the output set
     # because they're listed on some module's artifacts
     unit_11a = RpmUnit(
-        name="perl",
+        name="perl-version",
         filename="perl-version-1.99.24-441.module+el8.4.0+9911+7f269185.x86_64.rpm",
         version="1.99.24",
         release="441.module+el8.4.0+9911+7f269185",
@@ -426,10 +426,22 @@ def _prepare_test_data(pulp):
     )
 
     unit_11b = RpmUnit(
-        name="perl",
+        name="perl-version",
         filename="perl-version-0.99.24-441.module+el8.3.0+6718+7f269185.x86_64.rpm",
         version="0.99.24",
         release="441.module+el8.3.0+6718+7f269185",
+        epoch="0",
+        arch="x86_64",
+        provides=[],
+        requires=[],
+    )
+
+    # 11c package is non-modular variant of 11a/b that needs to be in the output set
+    unit_11c = RpmUnit(
+        name="perl-version",
+        filename="perl-version-0-1.x86_64.rpm",
+        version="0",
+        release="1",
         epoch="0",
         arch="x86_64",
         provides=[],
@@ -458,7 +470,7 @@ def _prepare_test_data(pulp):
         content_type_id="srpm",
     )
 
-    repo_1_units = [unit_1, unit_2, unit_5, unit_11a, unit_11b, unit_12]
+    repo_1_units = [unit_1, unit_2, unit_5, unit_11a, unit_11b, unit_11c, unit_12]
     repo_2_units = [unit_3, unit_4, unit_6]
     repo_srpm_units = [unit_9, unit_10, unit_13]
 

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -47,8 +47,8 @@ class Depsolver:
         # set of solvables (pkg, lib, ...) that we use for checking remaining requires
         self._unsolved: Set = set()
 
-        # List of all modular rpms available
-        self._modular_rpm_blacklist: Set = set()
+        # Set of all modular rpms
+        self._modular_rpms: Set = set()
 
         self._executor: ThreadPoolExecutor = Executors.thread_pool(
             max_workers=MAX_WORKERS
@@ -79,9 +79,7 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(
-            content, blacklist, self._modular_rpm_blacklist
-        )
+        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpms)
         return newest_rpms
 
     def get_modulemd_packages(self, repos, pkgs_list):
@@ -138,9 +136,7 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(
-            content, blacklist, self._modular_rpm_blacklist
-        )
+        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpms)
 
         return newest_rpms
 
@@ -170,8 +166,7 @@ class Depsolver:
             chain.from_iterable([repo.in_pulp_repos for repo in self.repos])
         )
         # get modular rpms first
-        _modular_rpms = self._get_pkgs_from_all_modules(pulp_repos)
-        self._modular_rpm_blacklist = _modular_rpms - self.modulemd_dependencies
+        self._modular_rpms = self._get_pkgs_from_all_modules(pulp_repos)
 
         merged_blacklist = list(
             chain.from_iterable([repo.blacklist for repo in self.repos])


### PR DESCRIPTION
In cases when ubi-manifest should include both modular and non-modular
variant of given package, one or the other could be omitted from output
depending on the version of the package.

Let's now switch to the following approach:
1) All modular RPMs are already known before RpmDepsolver starts
2) No other modular RPM can be added without its modulemd (all modulemd
   units are already resolved)
3) So we allow only non-modular RPMs to be added as dependencies, no
   need to add any more modular RPMs because of point 1.