### PR TITLE
Log properly failed depsolving of bool deps [RHELDST-12379]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -257,6 +257,8 @@ def test_run(pulp):
                 "lib.g",
                 "lib_exclude",
                 "lib.z",
+                "pkgX(abc)",
+                "capY(xyz)",
             }
 
             # unsolved set should be empty after depsolving finishes
@@ -266,7 +268,13 @@ def test_run(pulp):
             # there are unsolved requires, we can get those by
             unsolved = depsolver._requires - depsolver._provides
             # there is exactly two unresolved deps, lib_exclude is unsolved due to blacklisting
-            assert unsolved == {"lib.g", "lib_exclude", "blacklisted-package"}
+            assert unsolved == {
+                "pkgX(abc)",
+                "capY(xyz)",
+                "lib.g",
+                "lib_exclude",
+                "blacklisted-package",
+            }
 
             # checking correct rpm and srpm names and its associate source repo id
             output = [
@@ -294,6 +302,18 @@ def test_run(pulp):
                     "WARNING",
                     "Failed depsolving: blacklisted-package is blacklisted."
                     " These rpms depend on it ['lib-y-100-200.x86_64.rpm']",
+                ),
+                (
+                    "ubi_manifest.worker.tasks.depsolver.rpm_depsolver",
+                    "WARNING",
+                    "Failed depsolving: pkgX(abc) can not be found in these input repos:"
+                    " ['test_repo_1', 'test_repo_2']. These rpms depend on it ['lib-x-100-200.x86_64.rpm']",
+                ),
+                (
+                    "ubi_manifest.worker.tasks.depsolver.rpm_depsolver",
+                    "WARNING",
+                    "Failed depsolving: capY(xyz) can not be found in these input repos:"
+                    " ['test_repo_1', 'test_repo_2']. These rpms depend on it ['lib-x-100-200.x86_64.rpm']",
                 ),
                 order_matters=False,
             )
@@ -363,6 +383,7 @@ def _prepare_test_data(pulp):
         requires=[
             RpmDependency(name="lib.e"),
             RpmDependency(name="lib.g"),
+            RpmDependency(name="( pkgX(abc) with capY(xyz) )"),
             RpmDependency(name="lib_exclude"),
         ],
     )

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -295,12 +295,21 @@ class Depsolver:
                 return item.startswith(rule.name)
             return item == rule.name
 
+        def _requires_names(requires):
+            out = set()
+            for item in requires:
+                if item.name.startswith("("):
+                    out |= parse_bool_deps(item.name)
+                else:
+                    out.add(item.name)
+            return out
+
         # Get rpms depending on missing dependencies
         for item in deps_not_found:
             depending_rpms = list(
                 rpm.filename
                 for rpm in self.output_set
-                if item in map(lambda x: x.name, rpm.requires)
+                if item in _requires_names(rpm.requires)
             )
 
             # Divide missing dependencies blacklisted and all others


### PR DESCRIPTION
Bool deps on RPMs need parsing otherwise it won't be logged properly when depsolving failed.