### PR TITLE
Fix pip3 install permission issues due to user limitations

### DIFF
--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -4,7 +4,7 @@ LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
 
-# Switch to priviledged user to install rpm-devel
+# Switch to priviledged user to install dependencies and application
 USER 0
 
 # Enable CentOS repos, as rpm-devel is not in RHEL repos
@@ -17,13 +17,13 @@ RUN yum install -y --disableplugin=subscription-manager rpm-devel
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf
 
-# Switch back to unpriviledged user
-USER 1001
-
 COPY . .
 
 RUN pip3 install "uvicorn[standard]" gunicorn
 RUN pip3 install .
+
+# Switch back to unpriviledged user to run the application
+USER 1001
 
 EXPOSE 8000
 

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -4,7 +4,7 @@ LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
 
-# Switch to priviledged user to install rpm-devel
+# Switch to priviledged user to install dependencies and application
 USER 0
 
 # Enable CentOS repos, as rpm-devel is not in RHEL repos
@@ -21,11 +21,11 @@ COPY ./conf/app.conf /etc/ubi_manifest/app.conf
 COPY ./conf/certs/* /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust extract
 
-# Switch back to unpriviledged user
-USER 1001
-
 COPY . .
 
 RUN pip3 install .
+
+# Switch back to unpriviledged user to run the application
+USER 1001
 
 CMD celery -A ubi_manifest.worker.tasks worker --loglevel=debug

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
-requests
+httpx
 testfixtures


### PR DESCRIPTION
While trying to build the container image, `pip3 install *` errors out due to it being run under the unprivileged user and no `--user` or no virtualenv is being used to prevent permission issues.

Here, we move the switch to the unprivileged user after the `pip3 install *` commands.