### PR TITLE
Fix test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
-requests
+httpx
 testfixtures


### PR DESCRIPTION
TestClient from FastAPI started to use 'httpx' instead of 'requests'. Adding new requirement to test-requirements.txt.