### PR TITLE
Update pip in containers by default [RHELDST-15697]

### DIFF
--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -19,6 +19,7 @@ COPY ./conf/app.conf /etc/ubi_manifest/app.conf
 
 COPY . .
 
+RUN pip3 install -U pip
 RUN pip3 install "uvicorn[standard]" gunicorn
 RUN pip3 install .
 

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -23,6 +23,7 @@ RUN update-ca-trust extract
 
 COPY . .
 
+RUN pip3 install -U pip
 RUN pip3 install .
 
 # Switch back to unpriviledged user to run the application


### PR DESCRIPTION
Update pip in containers in order to have the latest version which should have the least number of vulnerabilities.