### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,18 +3,18 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py39:
+  py311:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py39
+        run: tox -e py311
   py310:
     runs-on: ubuntu-latest
     steps:
@@ -27,6 +27,18 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e py310
+  py39:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py39
   static:
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +58,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3.9
 -   repo: https://github.com/pycqa/isort/
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       args: ["--profile", "black"]

--- a/tests/test_modulemd_depsolver.py
+++ b/tests/test_modulemd_depsolver.py
@@ -153,7 +153,6 @@ def test_run(pulp):
 
 
 def _prepare_pulp(pulp):
-
     # Define mock repos
     repo_1 = create_and_insert_repo(id="test_repo_1", pulp=pulp)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -405,7 +405,6 @@ def test_parse_blacklist():
 
 
 def test_get_modulemd_output_set():
-
     # Define mock UbiUnits
 
     # two perl-YAML units with different versions, keep the highest version one

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = py39,py310
+envlist = py39,py310,py311
 
 [testenv]
 deps=-rtest-requirements.txt
 commands=pytest -v {posargs}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:static]
 deps=
 	-rtest-requirements.txt
-	black==22.3.0
+	black==23.3.0
 	pylint==2.12.2
 commands=
 	black --check .

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -35,7 +35,6 @@ class Depsolver:
         srpm_repos,
         modulemd_dependencies: Set[str],
     ) -> None:
-
         self.repos: List[DepsolverItem] = repos
         self.modulemd_dependencies: Set[str] = modulemd_dependencies
         self.output_set: Set[UbiUnit] = set()

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -39,7 +39,6 @@ def create_or_criteria(fields, values):
         if len(val_tuple) != len(fields):
             raise ValueError
         for index, field in enumerate(fields):
-
             inner_and_criteria.append(Criteria.with_field(field, val_tuple[index]))
 
         or_criteria.append(Criteria.and_(*inner_and_criteria))


### PR DESCRIPTION
* previously pinned version of `isort` and `black` didn't work together
  due to some incompatibilities

* bumped isort and black versions
* updates GH actions to run tests also on py311
* fix tox.ini - `allowlist_externals`
* applied suggested changes by `black`