### PR TITLE
Use rpmdyn instead of rpm-py-installer

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -47,6 +47,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install RPM
+        run: |
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     celery[redis]
     fastapi
     pubtools-pulplib
-    rpm-py-installer
+    rpmdyn
     attrs
     more-executors
     ubi-config

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -5,7 +5,11 @@ from logging import getLogger
 from typing import Dict, List, Tuple
 
 from pubtools.pulplib import Client, Criteria, Matcher
-from rpm import labelCompare as label_compare  # pylint: disable=no-name-in-module
+
+try:
+    from rpm import labelCompare as label_compare  # pylint: disable=no-name-in-module
+except ImportError as ex:
+    pass
 from ubiconfig import UbiConfig
 
 from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude


### PR DESCRIPTION
Beacuse of rpm-py-installer issue:
https://github.com/junaruga/rpm-py-installer/issues/276 we had to apply a certain workarounds across several projects.

It seems like the problem won't be fixed anytime soon, so let's try newly introduced python RPM bindings - rpmdyn instead of rpm-py-installer.