### PR TITLE
Fix CI and Dockerfiles for rpm-py-installer [RHELDST-17699]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py311
   py310:
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py310
   py39:
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e py39
   static:
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e static
   coverage:
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Tox
-        run: pip install tox
+        run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox
         run: tox -e cov
       - name: Install pytest cov

--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -19,7 +19,8 @@ COPY ./conf/app.conf /etc/ubi_manifest/app.conf
 
 COPY . .
 
-RUN pip3 install -U pip
+# install specific version of pip due to installation issue with rpm-py-installer
+RUN pip3 install pip==23.0.1
 RUN pip3 install "uvicorn[standard]" gunicorn
 RUN pip3 install .
 

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -23,7 +23,8 @@ RUN update-ca-trust extract
 
 COPY . .
 
-RUN pip3 install -U pip
+# install specific version of pip due to installation issue with rpm-py-installer
+RUN pip3 install pip==23.0.1
 RUN pip3 install .
 
 # Switch back to unpriviledged user to run the application


### PR DESCRIPTION
Due to issue https://github.com/rpm-py-installer/rpm-py-installer/issues/276
we need to install specific version of pip (Dockerfiles) and
vierualenv (CI). Newer versions of pip or virtualenv
made rpm-py-installer uninstallable.