### PR TITLE
Support for multiple content config sources [RHELDST-19139] 

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -4,8 +4,8 @@ pulp_username = x
 pulp_password = x
 pulp_cert = x
 pulp_key = x
-ubi_config_url = https://some-url
-allowed_ubi_repo_groups = {"example":
+content_config = {"repo_group_prefix": "url-to-config-repo"}
+allowed_ubi_repo_groups = {"repo_group_prefix:foo":
                             [
                             "repo_1",
                             "repo_2",

--- a/tests/data/conf/test.conf
+++ b/tests/data/conf/test.conf
@@ -4,7 +4,7 @@ pulp_username = xxx
 pulp_password = yyy
 pulp_cert = path/to/pulp_cert
 pulp_key = path/to/pulp_key
-ubi_config_url = https://gitlab.foo.bar.com/ubi-config
+content_config = {"ubi": "https://gitlab.foo.bar.com/ubi-config"}
 allowed_ubi_repo_groups = {"ubiX:test":
                             [
                             "repo_1",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -153,10 +153,9 @@ def test_manifest_post(client):
         # won't be able to find some deps that are not in the 'repo_1' but are
         # present in 'repo_2'
         # 'repo_not_allowed' is skipped completely
+        # the content config url is also determined from default conf and passed as arg
         mocked_apply_async.assert_called_once_with(
-            args=[
-                ["repo_1", "repo_2"],
-            ]
+            args=[["repo_1", "repo_2"], "url_to_config_repository"]
         )
 
         # expected status code is 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,9 +22,9 @@ def test_make_config():
         assert celery_app.conf["pulp_password"] == "yyy"
         assert celery_app.conf["pulp_cert"] == "path/to/pulp_cert"
         assert celery_app.conf["pulp_key"] == "path/to/pulp_key"
-        assert (
-            celery_app.conf["ubi_config_url"] == "https://gitlab.foo.bar.com/ubi-config"
-        )
+        assert celery_app.conf["content_config"] == {
+            "ubi": "https://gitlab.foo.bar.com/ubi-config"
+        }
         assert celery_app.conf["allowed_ubi_repo_groups"] == {
             "ubiX:test": ["repo_1", "repo_2", "repo_3"]
         }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -141,7 +141,7 @@ def test_depsolve_task(pulp):
 
                 client.return_value = pulp.client
                 # let run the depsolve task
-                result = depsolve.depsolve_task(["ubi_repo"])
+                result = depsolve.depsolve_task(["ubi_repo"], "fake-url")
                 # we don't return anything useful, everything is saved in redis
                 assert result is None
 
@@ -265,7 +265,7 @@ def test_depsolve_task_empty_manifests(pulp):
 
                 client.return_value = pulp.client
                 # let run the depsolve task
-                result = depsolve.depsolve_task(["ubi_repo"])
+                result = depsolve.depsolve_task(["ubi_repo"], "fake-url")
                 # we don't return anything useful, everything is saved in redis
                 assert result is None
 

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -62,8 +62,14 @@ def manifest_post(depsolve_item: DepsolveItem) -> List[TaskState]:
         )
 
     tasks_states = []
-    for repo_group in repo_groups.values():
-        task = depsolve_task.apply_async(args=[repo_group])
+    for repo_group_key, repo_group in repo_groups.items():
+        content_config_url = None
+        for group_prefix, url in app.conf.content_config.items():
+            if repo_group_key.startswith(group_prefix):
+                content_config_url = url
+                break
+
+        task = depsolve_task.apply_async(args=[repo_group, content_config_url])
         tasks_states.append(TaskState(task_id=task.task_id, state=task.state))
 
     return tasks_states

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -15,8 +15,8 @@ class Config:
     pulp_cert: str = "path/to/cert"
     pulp_key: str = "path/to/key"
     pulp_verify: Union[bool, str] = True
-    ubi_config_url: str = "some_url"
-    allowed_ubi_repo_groups: dict = {"group1": ["repo_1", "repo_2"]}
+    content_config: dict = {"group_prefix": "url_to_config_repository"}
+    allowed_ubi_repo_groups: dict = {"group_prefix1": ["repo_1", "repo_2"]}
     imports: List[str] = ["ubi_manifest.worker.tasks.depsolve"]
     broker_url: str = "redis://redis:6379/0"
     result_backend: str = "redis://redis:6379/0"
@@ -30,13 +30,12 @@ def make_config(celery_app):
     config_from_file = configparser.ConfigParser()
     config_from_file.read(config_file)
     try:
-        repo_groups_str = (
-            config_from_file["CONFIG"].pop("allowed_ubi_repo_groups") or ""
-        )
-        repo_groups_str = re.sub(r"[\s]+", "", repo_groups_str)
-        repo_groups = json.loads(repo_groups_str)
         conf_dict = dict(config_from_file["CONFIG"])
-        conf_dict["allowed_ubi_repo_groups"] = repo_groups
+        for conf_field in ("allowed_ubi_repo_groups", "content_config"):
+            conf_item_str = config_from_file["CONFIG"].pop(conf_field) or ""
+            conf_item = json.loads(re.sub(r"[\s]+", "", conf_item_str))
+            conf_dict[conf_field] = conf_item
+
         config = Config(**conf_dict)
     except KeyError:
         config = Config()

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -25,7 +25,7 @@ _LOG = logging.getLogger(__name__)
 
 
 @app.task
-def depsolve_task(ubi_repo_ids: List[str]) -> None:
+def depsolve_task(ubi_repo_ids: List[str], content_config_url: str) -> None:
     """
     Run depsolvers for given ubi_repo_ids - it's expected that id of binary
     repositories are provided. Debuginfo and SRPM repos related to those ones
@@ -36,7 +36,7 @@ def depsolve_task(ubi_repo_ids: List[str]) -> None:
     (source_repo_id, unit_type, unit_attr, value). Note that value in redis
     is stored as json string.
     """
-    ubi_config_loader = UbiConfigLoader(app.conf["ubi_config_url"])
+    ubi_config_loader = UbiConfigLoader(content_config_url)
 
     with make_pulp_client(app.conf) as client:
         repos_map = {}


### PR DESCRIPTION
Introduced new configuration option (json string) called
`content_config` with format `{repo_group_prefix: url}`.

Anytime clients request generation of the ubi-manifest for some
repositories, url of content configuration repository is
determined by matching the repo group prefix with `content_config`
configuration item.

Old config `ubi_config_url` was removed and only the new one
will be used.