### PR TITLE
Do not resolve non-modular RPM with modular RPM [RHELDST-18106]

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ from typing import List
 
 import ubiconfig
 from attrs import define
-from pubtools.pulplib import YumRepository
+from pubtools.pulplib import YumRepository, RpmDependency
 
 
 def create_and_insert_repo(**kwargs):
@@ -50,3 +50,7 @@ class MockedRedis:
 
     def keys(self) -> List[str]:
         return list(self.data.keys())
+
+
+def rpmdeps_from_names(*names):
+    return {RpmDependency(name=name) for name in names}


### PR DESCRIPTION
This change makes sure that non-modular RPM is NOT resolved
by modular RPM dependency. New behavior correctly resolves
all non-modular dependencies and there isn't happening any
unwanted combination of modular and non-modular deps which
led to uninstallable pkgs in practice.

Also this change added a functionality that resolves a requirement
also by flags ("EQ", "GT" and others) - which can be re-used
in future, if we would want to make the depsolver even more precise.