### PR TITLE
Population sources with different content sets [RHELDST-19356]

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,8 @@
 import json
 from unittest import mock
 
+import pytest
+
 from pubtools.pulplib import Distributor, ModulemdDefaultsUnit, ModulemdUnit, RpmUnit
 
 from ubi_manifest.worker.tasks import depsolve
@@ -10,7 +12,7 @@ from .utils import MockedRedis, MockLoader, create_and_insert_repo
 
 def test_depsolve_task(pulp):
     """
-    Simulate run of depsolve task, check expected output of depsolving.
+    Simulate run of depsolve task, check expected output of depsolving this the basic scenario with only one input repository.
     """
     ubi_repo = create_and_insert_repo(
         id="ubi_repo",
@@ -18,9 +20,21 @@ def test_depsolve_task(pulp):
         population_sources=["rhel_repo"],
         relative_url="foo/bar/os",
         ubi_config_version="8.4",
-        content_set="rpm_in",
+        content_set="cs_rpm_out",
     )
-    rhel_repo = create_and_insert_repo(id="rhel_repo", pulp=pulp)
+    distributor_rhel = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo",
+        relative_url="foo/rhel/os",
+    )
+    rhel_repo = create_and_insert_repo(
+        id="rhel_repo",
+        pulp=pulp,
+        content_set="cs_rpm_in",
+        relative_url="foo/rhel/os",
+        distributors=[distributor_rhel],
+    )
 
     distributor_debug = Distributor(
         id="yum_distributor",
@@ -35,8 +49,22 @@ def test_depsolve_task(pulp):
         population_sources=["rhel_debug_repo"],
         relative_url="foo/bar/debug",
         distributors=[distributor_debug],
+        content_set="cs_debug_out",
     )
-    rhel_debug_repo = create_and_insert_repo(id="rhel_debug_repo", pulp=pulp)
+
+    distributor_rhel_debug = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo",
+        relative_url="foo/rhel/debug",
+    )
+    rhel_debug_repo = create_and_insert_repo(
+        id="rhel_debug_repo",
+        pulp=pulp,
+        content_set="cs_debug_in",
+        relative_url="foo/rhel/debug",
+        distributors=[distributor_rhel_debug],
+    )
 
     distributor_source = Distributor(
         id="yum_distributor",
@@ -51,8 +79,11 @@ def test_depsolve_task(pulp):
         population_sources=["rhel_source_repo"],
         relative_url="foo/bar/source/SRPMS",
         distributors=[distributor_source],
+        content_set="cs_srpm_out",
     )
-    rhel_source_repo = create_and_insert_repo(id="rhel_source_repo", pulp=pulp)
+    rhel_source_repo = create_and_insert_repo(
+        id="rhel_source_repo", pulp=pulp, content_set="cs_srpm_in"
+    )
 
     unit_binary = RpmUnit(
         name="gcc",
@@ -219,9 +250,21 @@ def test_depsolve_task_empty_manifests(pulp):
         population_sources=["rhel_repo"],
         relative_url="foo/bar/os",
         ubi_config_version="8.4",
-        content_set="rpm_in",
+        content_set="cs_rpm_out",
     )
-    rhel_repo = create_and_insert_repo(id="rhel_repo", pulp=pulp)
+    distributor_rhel = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo",
+        relative_url="foo/rhel/os",
+    )
+    rhel_repo = create_and_insert_repo(
+        id="rhel_repo",
+        pulp=pulp,
+        content_set="cs_rpm_in",
+        relative_url="foo/rhel/os",
+        distributors=[distributor_rhel],
+    )
 
     distributor_debug = Distributor(
         id="yum_distributor",
@@ -236,8 +279,22 @@ def test_depsolve_task_empty_manifests(pulp):
         population_sources=["rhel_debug_repo"],
         relative_url="foo/bar/debug",
         distributors=[distributor_debug],
+        content_set="cs_debug_out",
     )
-    rhel_debug_repo = create_and_insert_repo(id="rhel_debug_repo", pulp=pulp)
+
+    distributor_rhel_debug = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo",
+        relative_url="foo/rhel/debug",
+    )
+    rhel_debug_repo = create_and_insert_repo(
+        id="rhel_debug_repo",
+        pulp=pulp,
+        content_set="cs_debug_in",
+        relative_url="foo/rhel/debug",
+        distributors=[distributor_rhel_debug],
+    )
 
     distributor_source = Distributor(
         id="yum_distributor",
@@ -252,8 +309,11 @@ def test_depsolve_task_empty_manifests(pulp):
         population_sources=["rhel_source_repo"],
         relative_url="foo/bar/source/SRPMS",
         distributors=[distributor_source],
+        content_set="cs_srpm_out",
     )
-    rhel_source_repo = create_and_insert_repo(id="rhel_source_repo", pulp=pulp)
+    rhel_source_repo = create_and_insert_repo(
+        id="rhel_source_repo", pulp=pulp, content_set="cs_srpm_in"
+    )
 
     with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
@@ -286,3 +346,579 @@ def test_depsolve_task_empty_manifests(pulp):
                     content = json.loads(data)
                     # content should be empty
                     assert len(content) == 0
+
+
+def _setup_data_multiple_population_sources(pulp):
+    ubi_repo = create_and_insert_repo(
+        id="ubi_repo",
+        pulp=pulp,
+        population_sources=[
+            "rhel_repo-1",
+            "rhel_repo-2",
+            "rhel_repo-other-1",
+            "rhel_repo-other-2",
+        ],
+        relative_url="foo/bar/os",
+        ubi_config_version="8.4",
+        content_set="cs_rpm_out",
+    )
+    distributor_rhel_1 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo-1",
+        relative_url="foo/rhel-1/os",
+    )
+    distributor_rhel_2 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo-2",
+        relative_url="foo/rhel-2/os",
+    )
+    rhel_repo_1 = create_and_insert_repo(
+        id="rhel_repo-1",
+        pulp=pulp,
+        content_set="cs_rpm_in",
+        relative_url="foo/rhel-1/os",
+        distributors=[distributor_rhel_1],
+    )
+    rhel_repo_2 = create_and_insert_repo(
+        id="rhel_repo-2",
+        pulp=pulp,
+        content_set="cs_rpm_in",
+        relative_url="foo/rhel-2/os",
+        distributors=[distributor_rhel_2],
+    )
+
+    distributor_rhel_other_1 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo-other-1",
+        relative_url="foo/rhel-other-1/os",
+    )
+    distributor_rhel_other_2 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo-other-2",
+        relative_url="foo/rhel-other-2/os",
+    )
+
+    rhel_repo_other_1 = create_and_insert_repo(
+        id="rhel_repo-other-1",
+        pulp=pulp,
+        content_set="cs_rpm_in_other",
+        relative_url="foo/rhel-other-1/os",
+        distributors=[distributor_rhel_other_1],
+    )
+    rhel_repo_other_2 = create_and_insert_repo(
+        id="rhel_repo-other-2",
+        pulp=pulp,
+        content_set="cs_rpm_in_other",
+        relative_url="foo/rhel-other-2/os",
+        distributors=[distributor_rhel_other_2],
+    )
+
+    distributor_debug = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="ubi_debug_repo",
+        relative_url="foo/bar/debug",
+    )
+
+    ubi_debug_repo = create_and_insert_repo(
+        id="ubi_debug_repo",
+        pulp=pulp,
+        population_sources=[
+            "rhel_debug_repo-1",
+            "rhel_debug_repo-2",
+            "rhel_debug_repo-other-1",
+            "rhel_debug_repo-other-2",
+        ],
+        relative_url="foo/bar/debug",
+        distributors=[distributor_debug],
+        content_set="cs_debug_out",
+    )
+
+    distributor_rhel_debug_1 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo-1",
+        relative_url="foo/rhel-1/debug",
+    )
+    distributor_rhel_debug_2 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo-2",
+        relative_url="foo/rhel-2/debug",
+    )
+    rhel_debug_repo_1 = create_and_insert_repo(
+        id="rhel_debug_repo-1",
+        pulp=pulp,
+        content_set="cs_debug_in",
+        relative_url="foo/rhel-1/debug",
+        distributors=[distributor_rhel_debug_1],
+    )
+    rhel_debug_repo_2 = create_and_insert_repo(
+        id="rhel_debug_repo-2",
+        pulp=pulp,
+        content_set="cs_debug_in",
+        relative_url="foo/rhel-2/debug",
+        distributors=[distributor_rhel_debug_2],
+    )
+
+    distributor_rhel_debug_other_1 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo-other-1",
+        relative_url="foo/rhel-other-1/debug",
+    )
+    distributor_rhel_debug_other_2 = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo-other-2",
+        relative_url="foo/rhel-other-2/debug",
+    )
+    rhel_debug_repo_other_1 = create_and_insert_repo(
+        id="rhel_debug_repo-other-1",
+        pulp=pulp,
+        content_set="cs_debug_in_other",
+        relative_url="foo/rhel-other-1/debug",
+        distributors=[distributor_rhel_debug_other_1],
+    )
+    rhel_debug_repo_other_2 = create_and_insert_repo(
+        id="rhel_debug_repo-other-2",
+        pulp=pulp,
+        content_set="cs_debug_in_other",
+        relative_url="foo/rhel-other-2/debug",
+        distributors=[distributor_rhel_debug_other_2],
+    )
+
+    distributor_source = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="ubi_source_repo",
+        relative_url="foo/bar/source/SRPMS",
+    )
+
+    ubi_source_repo = create_and_insert_repo(
+        id="ubi_source_repo",
+        pulp=pulp,
+        population_sources=["rhel_source_repo", "rhel_source_repo-other"],
+        relative_url="foo/bar/source/SRPMS",
+        distributors=[distributor_source],
+        content_set="cs_srpm_out",
+    )
+    rhel_source_repo = create_and_insert_repo(
+        id="rhel_source_repo", pulp=pulp, content_set="cs_srpm_in"
+    )
+    rhel_source_repo_other = create_and_insert_repo(
+        id="rhel_source_repo-other", pulp=pulp, content_set="cs_srpm_in_other"
+    )
+
+    unit_1 = RpmUnit(
+        name="gcc",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        sourcerpm="gcc_src-1-0.src.rpm",
+        filename="gcc-10.200.x86_64.rpm",
+        requires=[],
+        provides=[],
+    )
+
+    unit_2 = RpmUnit(
+        name="gcc",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc-11.200.x86_64.rpm",
+        sourcerpm="gcc_src-2-0.src.rpm",
+    )
+
+    unit_3 = RpmUnit(
+        name="bind",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        sourcerpm="bind_src-1-0.src.rpm",
+        filename="bind-10.200.x86_64.rpm",
+        requires=[],
+        provides=[],
+    )
+
+    unit_4 = RpmUnit(
+        name="bind",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind-11.200.x86_64.rpm",
+        sourcerpm="bind_src-2-0.src.rpm",
+    )
+
+    unit_debuginfo_1 = RpmUnit(
+        name="gcc-debuginfo",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc-debuginfo-10.200.x86_64.rpm",
+        sourcerpm="gcc_src-1-0.src.rpm",
+    )
+    unit_debuginfo_2 = RpmUnit(
+        name="gcc-debuginfo",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc-debuginfo-11.200.x86_64.rpm",
+        sourcerpm="gcc_src-1-0.src.rpm",
+    )
+    unit_debugsource_1 = RpmUnit(
+        name="gcc_src-debugsource",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc_src-debugsource-11.200.x86_64.rpm",
+        sourcerpm="gcc_src_debug-1-0.src.rpm",
+    )
+    unit_debugsource_2 = RpmUnit(
+        name="gcc_src-debugsource",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc_src-debugsource-10.200.x86_64.rpm",
+        sourcerpm="gcc_src_debug-1-0.src.rpm",
+    )
+
+    unit_debuginfo_3 = RpmUnit(
+        name="bind-debuginfo",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind-debuginfo-10.200.x86_64.rpm",
+        sourcerpm="bind_src-2-0.src.rpm",
+    )
+    unit_debuginfo_4 = RpmUnit(
+        name="bind-debuginfo",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind-debuginfo-11.200.x86_64.rpm",
+        sourcerpm="bind_src-1-0.src.rpm",
+    )
+    unit_debugsource_3 = RpmUnit(
+        name="bind_src-debugsource",
+        version="11",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind_src-debugsource-11.200.x86_64.rpm",
+        sourcerpm="bind_src_debug-2-0.src.rpm",
+    )
+    unit_debugsource_4 = RpmUnit(
+        name="bind_src-debugsource",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind_src-debugsource-10.200.x86_64.rpm",
+        sourcerpm="bind_src_debug-1-0.src.rpm",
+    )
+
+    unit_srpm = RpmUnit(
+        name="gcc_src",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc_src-1-0.src.rpm",
+        content_type_id="srpm",
+    )
+    unit_srpm_debug = RpmUnit(
+        name="gcc_src_debug",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc_src_debug-1-0.src.rpm",
+        content_type_id="srpm",
+    )
+    unit_srpm = RpmUnit(
+        name="gcc_src",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="gcc_src-1-0.src.rpm",
+        content_type_id="srpm",
+    )
+
+    unit_srpm_other = RpmUnit(
+        name="bind_src",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind_src-2-0.src.rpm",
+        content_type_id="srpm",
+    )
+
+    unit_srpm_debug_other = RpmUnit(
+        name="bind_src_debug",
+        version="10",
+        release="200",
+        epoch="1",
+        arch="x86_64",
+        requires=[],
+        provides=[],
+        filename="bind_src_debug-2-0.src.rpm",
+        content_type_id="srpm",
+    )
+
+    pulp.insert_units(rhel_repo_1, [unit_1])
+    pulp.insert_units(rhel_repo_2, [unit_2])
+    pulp.insert_units(rhel_repo_other_1, [unit_3])
+    pulp.insert_units(rhel_repo_other_2, [unit_4])
+
+    pulp.insert_units(rhel_debug_repo_1, [unit_debuginfo_1, unit_debugsource_1])
+    pulp.insert_units(rhel_debug_repo_2, [unit_debuginfo_2, unit_debugsource_2])
+    pulp.insert_units(rhel_debug_repo_other_1, [unit_debuginfo_3, unit_debugsource_3])
+    pulp.insert_units(rhel_debug_repo_other_2, [unit_debuginfo_4, unit_debugsource_4])
+
+    pulp.insert_units(rhel_source_repo, [unit_srpm, unit_srpm_debug])
+    pulp.insert_units(rhel_source_repo_other, [unit_srpm_other, unit_srpm_debug_other])
+
+
+def test_multiple_population_sources(pulp):
+    """Test more complicated scenario when the output repo is expected
+    to be populated with multiple input repos. Each input repo can have different content set
+    and content config. Configs cannot be mixed between repos with different input content set.
+    """
+    _setup_data_multiple_population_sources(pulp)
+
+    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+        with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
+            with mock.patch(
+                "ubi_manifest.worker.tasks.depsolve.redis.from_url"
+            ) as mock_redis_from_url:
+                redis = MockedRedis(data={})
+                mock_redis_from_url.return_value = redis
+
+                client.return_value = pulp.client
+                # let run the depsolve task
+                result = depsolve.depsolve_task(["ubi_repo"], "fake-url")
+                # we don't return anything useful, everything is saved in redis
+                assert result is None
+
+                # there should 3 keys stored in redis
+                assert sorted(redis.keys()) == [
+                    "ubi_debug_repo",
+                    "ubi_repo",
+                    "ubi_source_repo",
+                ]
+
+                # load json string stored in redis
+                data = redis.get("ubi_repo")
+                content = sorted(json.loads(data), key=lambda d: d["value"])
+                # binary repo contains only 2 rpms but each unit has different src_repo_id
+                assert len(content) == 2
+
+                unit = content[0]
+                assert unit["src_repo_id"] == "rhel_repo-other-2"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "bind-11.200.x86_64.rpm"
+
+                unit = content[1]
+                assert unit["src_repo_id"] == "rhel_repo-2"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "gcc-11.200.x86_64.rpm"
+
+                # load json string stored in redis
+                data = redis.get("ubi_debug_repo")
+                content = sorted(json.loads(data), key=lambda d: d["value"])
+
+                # debuginfo repo contains 4 debug packages
+                # `bind`` pkgs from rhel_debug_repo-other* repos different content set and config)
+                # `gcc` pkgs from rhel_debug_repo* repo (different content set and config)
+                assert len(content) == 4
+
+                unit = content[0]
+                assert unit["src_repo_id"] == "rhel_debug_repo-other-2"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "bind-debuginfo-11.200.x86_64.rpm"
+
+                unit = content[1]
+                assert unit["src_repo_id"] == "rhel_debug_repo-other-1"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "bind_src-debugsource-11.200.x86_64.rpm"
+
+                unit = content[2]
+                assert unit["src_repo_id"] == "rhel_debug_repo-2"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "gcc-debuginfo-11.200.x86_64.rpm"
+
+                unit = content[3]
+                assert unit["src_repo_id"] == "rhel_debug_repo-1"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "gcc_src-debugsource-11.200.x86_64.rpm"
+
+                # load json string stored in redis
+                data = redis.get("ubi_source_repo")
+                content = sorted(json.loads(data), key=lambda d: d["value"])
+                # source repo contain 4 SRPM packages, no duplicates, correct src_repo_ids
+                assert len(content) == 4
+                unit = content[0]
+                assert unit["src_repo_id"] == "rhel_source_repo-other"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "bind_src-2-0.src.rpm"
+
+                unit = content[1]
+                assert unit["src_repo_id"] == "rhel_source_repo-other"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "bind_src_debug-2-0.src.rpm"
+
+                unit = content[2]
+                assert unit["src_repo_id"] == "rhel_source_repo"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "gcc_src-1-0.src.rpm"
+
+                unit = content[3]
+                assert unit["src_repo_id"] == "rhel_source_repo"
+                assert unit["unit_type"] == "RpmUnit"
+                assert unit["unit_attr"] == "filename"
+                assert unit["value"] == "gcc_src_debug-1-0.src.rpm"
+
+
+def test_missing_content_config(pulp):
+    """Exception is raised where there is no matching ubi content config"""
+    _setup_repos_missing_config(pulp)
+
+    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+        with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
+            with mock.patch(
+                "ubi_manifest.worker.tasks.depsolve.redis.from_url"
+            ) as mock_redis_from_url:
+                redis = MockedRedis(data={})
+                mock_redis_from_url.return_value = redis
+
+                client.return_value = pulp.client
+                # let run the depsolve task
+                with pytest.raises(depsolve.ContentConfigMissing):
+                    _ = depsolve.depsolve_task(["ubi_repo"], "fake-url")
+
+
+def _setup_repos_missing_config(pulp):
+    ubi_repo = create_and_insert_repo(
+        id="ubi_repo",
+        pulp=pulp,
+        population_sources=["rhel_repo"],
+        relative_url="foo/bar/os",
+        ubi_config_version="8.4",
+        content_set="cs_rpm_out_missing",
+    )
+    distributor_rhel = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_repo",
+        relative_url="foo/rhel/os",
+    )
+    rhel_repo = create_and_insert_repo(
+        id="rhel_repo",
+        pulp=pulp,
+        content_set="cs_rpm_in",
+        relative_url="foo/rhel/os",
+        distributors=[distributor_rhel],
+    )
+
+    distributor_debug = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="ubi_debug_repo",
+        relative_url="foo/bar/debug",
+    )
+
+    ubi_debug_repo = create_and_insert_repo(
+        id="ubi_debug_repo",
+        pulp=pulp,
+        population_sources=["rhel_debug_repo"],
+        relative_url="foo/bar/debug",
+        distributors=[distributor_debug],
+        content_set="cs_debug_out",
+    )
+
+    distributor_rhel_debug = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="rhel_debug_repo",
+        relative_url="foo/rhel/debug",
+    )
+    rhel_debug_repo = create_and_insert_repo(
+        id="rhel_debug_repo",
+        pulp=pulp,
+        content_set="cs_debug_in",
+        relative_url="foo/rhel/debug",
+        distributors=[distributor_rhel_debug],
+    )
+
+    distributor_source = Distributor(
+        id="yum_distributor",
+        type_id="yum_distributor",
+        repo_id="ubi_source_repo",
+        relative_url="foo/bar/source/SRPMS",
+    )
+
+    ubi_source_repo = create_and_insert_repo(
+        id="ubi_source_repo",
+        pulp=pulp,
+        population_sources=["rhel_source_repo"],
+        relative_url="foo/bar/source/SRPMS",
+        distributors=[distributor_source],
+        content_set="cs_srpm_out",
+    )
+    rhel_source_repo = create_and_insert_repo(
+        id="rhel_source_repo", pulp=pulp, content_set="cs_srpm_in"
+    )

--- a/tests/test_ubi_config.py
+++ b/tests/test_ubi_config.py
@@ -8,27 +8,28 @@ from .utils import MockLoader
 def test_get_config():
     with mock.patch("ubiconfig.get_loader", return_value=MockLoader()) as mock_loader:
         loader = UbiConfigLoader("https://foo.bar.com/some-repo.git")
-        config = loader.get_config("rpm_out", "8")
+        config = loader.get_config("cs_rpm_in", "cs_rpm_out", "8")
 
         # let's check what we got
         assert config.version == "8"
-        assert config.content_sets.rpm.input == "rpm_in"
-        assert config.content_sets.rpm.output == "rpm_out"
-        assert config.content_sets.srpm.input == "srpm_in"
-        assert config.content_sets.srpm.output == "srpm_out"
-        assert config.content_sets.debuginfo.input == "debug_in"
-        assert config.content_sets.debuginfo.output == "debug_out"
+        assert config.content_sets.rpm.input == "cs_rpm_in"
+        assert config.content_sets.rpm.output == "cs_rpm_out"
+        assert config.content_sets.srpm.input == "cs_srpm_in"
+        assert config.content_sets.srpm.output == "cs_srpm_out"
+        assert config.content_sets.debuginfo.input == "cs_debug_in"
+        assert config.content_sets.debuginfo.output == "cs_debug_out"
 
-        # there should be six entries in the loader._config_map dict
-        assert len(loader._config_map.keys()) == 6
+        # there should be three entries in the loader._config_map dict
+        # each unique combo of (cs_in, cs_out, version)
+        assert len(loader._config_map.keys()) == 3
 
         # check one of the entry
-        config_to_check = loader._config_map[("debug_in", "8")]
+        config_to_check = loader._config_map[("cs_debug_in", "cs_debug_out", "8")]
         # it should be the same object as the original config
         assert config is config_to_check
 
         # call it once more again
-        _ = loader.get_config("rpm_out", "8")
+        _ = loader.get_config("cs_debug_in", "cs_debug_out", "8")
 
         # mock_loader ("ubiconfig.get_loader") should be called only once
         # second call of loader.get_config() reads from loader._config_map

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -382,7 +382,7 @@ def test_split_filename(filename, name, ver, rel, epoch, arch):
 def test_parse_blacklist():
     with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
         loader = UbiConfigLoader("https://foo.bar.com/some-repo.git")
-        config = loader.get_config("rpm_out", "8")
+        config = loader.get_config("cs_rpm_in", "cs_rpm_out", "8")
 
         parsed = parse_blacklist_config(config)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ def create_and_insert_repo(**kwargs):
 
 class MockLoader:
     def load_all(self):
-        config_raw = {
+        config_raw_1 = {
             "modules": {
                 "include": [
                     {
@@ -28,14 +28,43 @@ class MockLoader:
                 "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],
             },
             "content_sets": {
-                "rpm": {"output": "rpm_out", "input": "rpm_in"},
-                "srpm": {"output": "srpm_out", "input": "srpm_in"},
-                "debuginfo": {"output": "debug_out", "input": "debug_in"},
+                "rpm": {"output": "cs_rpm_out", "input": "cs_rpm_in"},
+                "srpm": {"output": "cs_srpm_out", "input": "cs_srpm_in"},
+                "debuginfo": {"output": "cs_debug_out", "input": "cs_debug_in"},
             },
             "arches": ["x86_64", "src"],
         }
 
-        return [ubiconfig.UbiConfig.load_from_dict(config_raw, "foo", "8")]
+        config_raw_2 = {
+            "modules": {
+                "include": [
+                    {
+                        "name": "fake_name",
+                        "stream": "fake_stream",
+                    }
+                ]
+            },
+            "packages": {
+                "include": [
+                    "package-name-.*",
+                    "gcc.*",
+                    "httpd.src",
+                    "pkg-debuginfo.*",
+                    "bind.*",
+                ],
+                "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],
+            },
+            "content_sets": {
+                "rpm": {"output": "cs_rpm_out", "input": "cs_rpm_in_other"},
+                "srpm": {"output": "cs_srpm_out", "input": "cs_srpm_in_other"},
+                "debuginfo": {"output": "cs_debug_out", "input": "cs_debug_in_other"},
+            },
+            "arches": ["x86_64", "src"],
+        }
+        return [
+            ubiconfig.UbiConfig.load_from_dict(config, file, "8")
+            for config, file in [(config_raw_1, "file_1"), (config_raw_2, "file_2")]
+        ]
 
 
 @define

--- a/ubi_manifest/worker/tasks/depsolver/ubi_config.py
+++ b/ubi_manifest/worker/tasks/depsolver/ubi_config.py
@@ -24,29 +24,40 @@ class UbiConfigLoader:
         loader = ubiconfig.get_loader(self._url)
         return loader.load_all()
 
-    def get_config(self, content_set_name: str, version: str) -> ubiconfig.UbiConfig:
-        """Gets and returns UbiConfig for given content_set_name and version"""
-        out = self._config_map.get((content_set_name, version)) or None
+    def get_config(
+        self, input_cs: str, output_cs: str, version: str
+    ) -> ubiconfig.UbiConfig:
+        """Gets and returns UbiConfig for given input content set, output content set and a version"""
+        out = self._config_map.get((input_cs, output_cs, version)) or None
 
         if out is None:
             for config in self.all_config:
-                for cs_name in self._all_content_sets_in_config(config):
-                    self._config_map.setdefault((cs_name, config.version), config)
+                for cs_in, cs_out in self._content_sets(config):
+                    self._config_map.setdefault((cs_in, cs_out, config.version), config)
 
                 if config.version == version:
-                    if content_set_name in self._all_content_sets_in_config(config):
+                    if (
+                        input_cs,
+                        output_cs,
+                    ) in self._content_sets(config):
                         out = config
                         break
 
         return out
 
     @staticmethod
-    def _all_content_sets_in_config(config: ubiconfig.UbiConfig) -> List[str]:
+    def _content_sets(config: ubiconfig.UbiConfig) -> List[str]:
         return [
-            config.content_sets.rpm.input,
-            config.content_sets.debuginfo.input,
-            config.content_sets.srpm.input,
-            config.content_sets.rpm.output,
-            config.content_sets.debuginfo.output,
-            config.content_sets.srpm.output,
+            (
+                config.content_sets.rpm.input,
+                config.content_sets.rpm.output,
+            ),
+            (
+                config.content_sets.debuginfo.input,
+                config.content_sets.debuginfo.output,
+            ),
+            (
+                config.content_sets.srpm.input,
+                config.content_sets.srpm.output,
+            ),
         ]


### PR DESCRIPTION
This commit adds support for population sources with different
content sets. Each input repo can use different ubi content config
depending on the input and output content sets and a version.
This means that one output repository can be populated using
more input repositories with different content config files.

Fetching ubi content config is now more precise because the same
output content set can be defined in more than one ubi content
config file. We need to query config by input and output content set
and a version.