### PR TITLE
Fix tox-test workflow trigger

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on:
   pull_request:
   push:
-    branches: main
+    branches: master
 
 
 jobs:


### PR DESCRIPTION
The trigger was incorrectly set to branch main, we change it to master.