### PR TITLE
Fix keeping n latest rpms for different arches [RHELDST-21855]

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,15 +206,31 @@ def _testdata(n):
         out = [unit_noarch, unit_i686_higher, unit_x86_64_higher]
     elif n >= 3:
         # all pkgs will be in output
-        out = [unit_noarch, unit_i686_higher, unit_x86_64_higher, unit_i686_lower, unit_x86_64_lower]
-    
-    return n, [unit_x86_64_lower, unit_i686_lower, unit_x86_64_higher, unit_i686_higher, unit_noarch], out
-    
+        out = [
+            unit_noarch,
+            unit_i686_higher,
+            unit_x86_64_higher,
+            unit_i686_lower,
+            unit_x86_64_lower,
+        ]
+
+    return (
+        n,
+        [
+            unit_x86_64_lower,
+            unit_i686_lower,
+            unit_x86_64_higher,
+            unit_i686_higher,
+            unit_noarch,
+        ],
+        out,
+    )
+
 
 @pytest.mark.parametrize(
     "n, input, expected_result",
-    [_testdata(1), _testdata(2), _testdata(3)]
-,)
+    [_testdata(1), _testdata(2), _testdata(3)],
+)
 def test_keep_n_latest_rpms_multiple_arches_different_n(n, input, expected_result):
     """Test keeping only the latest version of rpm for multiple arches
     with different `n` parameter"""

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -200,11 +200,11 @@ def _keep_n_latest_rpms(rpms, n=1):
     """
     # Use a queue of n elements per arch
     pkgs_per_arch = defaultdict(lambda: deque(maxlen=n))
-    
+
     allowed_versions = set()
     for rpm in sorted(rpms, key=vercmp_sort(), reverse=True):
         allowed_versions.add(rpm.version)
-        
+
         if len(allowed_versions) > n:
             break
 


### PR DESCRIPTION
Yum repositories can contain rpms with different arches of the same package. We need to make sure that only the highest and the same version of rpms are kept.

Previously output contained in some cases pkg.arch_x.v_1 and pkg.arch_y.v2 which is incorrect because of mixed versions and for some workflows system can end up in the uninstallable state.

This change makes sure that only pkg.arch_x.v_1 and pkg_arch_y.v_1 (if present) will be in output and it won't end with mixed versions.

This is also fixed for parameter n>=2 which not used currently in practice.