### PR TITLE
Fix `keep_n_latest` for identical versions

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,6 +154,7 @@ def test_keep_n_latest_rpms_multiple_arches_default_n():
     assert rpms[1].release == "el8"
     assert rpms[1].arch == "i686"
 
+
 def test_keep_n_latest_rpms_multiple_arches_default_n_same_version():
     """Test keeping only the latest version of rpm for multiple arches and
     the same version. Pkgs differ in release, the highest release value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -144,14 +144,71 @@ def test_keep_n_latest_rpms_multiple_arches_default_n():
     # there should be 2 rpms
     assert len(rpms) == 2
 
-    # i686 rpm goes with its highest version
+    # x86_64 rpm goes with its highest version
     assert rpms[0].version == "11"
     assert rpms[0].release == "el8"
     assert rpms[0].arch == "x86_64"
 
-    # x86_64 rpm goes with its highest version
+    # i686 rpm goes with its highest version
     assert rpms[1].version == "11"
     assert rpms[1].release == "el8"
+    assert rpms[1].arch == "i686"
+
+def test_keep_n_latest_rpms_multiple_arches_default_n_same_version():
+    """Test keeping only the latest version of rpm for multiple arches and
+    the same version. Pkgs differ in release, the highest release value
+    goes to output."""
+
+    unit_1 = get_ubi_unit(
+        RpmUnit,
+        "test_repo_id",
+        name="test",
+        version="10",
+        release="1.el8",
+        arch="x86_64",
+    )
+    unit_2 = get_ubi_unit(
+        RpmUnit,
+        "test_repo_id",
+        name="test",
+        version="10",
+        release="2.el8",
+        arch="x86_64",
+    )
+    unit_3 = get_ubi_unit(
+        RpmUnit,
+        "test_repo_id",
+        name="test",
+        version="10",
+        release="1.el8",
+        arch="i686",
+    )
+    unit_4 = get_ubi_unit(
+        RpmUnit,
+        "test_repo_id",
+        name="test",
+        version="10",
+        release="2.el8",
+        arch="i686",
+    )
+
+    rpms = [unit_1, unit_2, unit_3, unit_4]
+    _keep_n_latest_rpms(rpms)
+
+    # sort by version, the order after _keep_n_latest_rpms() is not guaranteed in this case
+    rpms.sort(key=lambda x: x.version)
+
+    # there should be 2 rpms
+    assert len(rpms) == 2
+
+    # x86_64 rpm goes with its highest version and release
+    assert rpms[0].version == "10"
+    assert rpms[0].release == "2.el8"
+    assert rpms[0].arch == "x86_64"
+
+    # i686 rpm goes with its highest version and release
+    assert rpms[1].version == "10"
+    assert rpms[1].release == "2.el8"
     assert rpms[1].arch == "i686"
 
 

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -200,15 +200,23 @@ def _keep_n_latest_rpms(rpms, n=1):
     """
     # Use a queue of n elements per arch
     pkgs_per_arch = defaultdict(lambda: deque(maxlen=n))
-    
+
     # set of allowed (version, release) tuples
     allowed_ver_rel = set()
     for rpm in sorted(rpms, key=vercmp_sort(), reverse=True):
-        allowed_ver_rel.add((rpm.version, rpm.release,))
+        allowed_ver_rel.add(
+            (
+                rpm.version,
+                rpm.release,
+            )
+        )
         if len(allowed_ver_rel) > n:
             break
 
-        if (rpm.version, rpm.release,) in allowed_ver_rel:
+        if (
+            rpm.version,
+            rpm.release,
+        ) in allowed_ver_rel:
             pkgs_per_arch[rpm.arch].append(rpm)
 
     latest_pkgs_per_arch = list(chain.from_iterable(pkgs_per_arch.values()))

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -200,15 +200,15 @@ def _keep_n_latest_rpms(rpms, n=1):
     """
     # Use a queue of n elements per arch
     pkgs_per_arch = defaultdict(lambda: deque(maxlen=n))
-
-    allowed_versions = set()
+    
+    # set of allowed (version, release) tuples
+    allowed_ver_rel = set()
     for rpm in sorted(rpms, key=vercmp_sort(), reverse=True):
-        allowed_versions.add(rpm.version)
-
-        if len(allowed_versions) > n:
+        allowed_ver_rel.add((rpm.version, rpm.release,))
+        if len(allowed_ver_rel) > n:
             break
 
-        if rpm.version in allowed_versions:
+        if (rpm.version, rpm.release,) in allowed_ver_rel:
             pkgs_per_arch[rpm.arch].append(rpm)
 
     latest_pkgs_per_arch = list(chain.from_iterable(pkgs_per_arch.values()))


### PR DESCRIPTION
In practice pkgs typically have identical versions but differ only in release values. This was overlooked in the previous commit 6526f0961952b34a7a7948d0fb4a5c5fd79b0dd7 which allowed to select not the newest rpms according to evr.

This commit fixes the behavior as takes also `release` value into account.