### PR TITLE
Modify Renovate PR frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeSchedule": ["0 12 * * 2"]
+    }
+  ],
+  "schedule": ["every weekend"]
 }
+


### PR DESCRIPTION
We modify renovate setting to let the PRs to be submitted on weekends and to be merged automatically on Tuesday noon for non-major version updates.