### PR TITLE
Ensure openapi files are copied to docs [RHELDST-21869]

### DIFF
--- a/scripts/gen-openapi
+++ b/scripts/gen-openapi
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # Helper script to generate openapi JSON file
 # during publishing of docs.
+import os
 import json
+import shutil
 
 
 from ubi_manifest.app.factory import create_app
@@ -10,3 +12,6 @@ api = create_app().openapi()
 
 with open("docs/openapi/openapi.json", "wt") as f:
     json.dump(api, f)
+
+for f in os.listdir("docs/openapi"):
+    shutil.copy("docs/openapi/" + f, "docs/_build/html")

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ commands=
 use_develop=true
 commands=
         poetry install --with docs
-	python scripts/gen-openapi
-	sphinx-build -M html docs docs/_build -W
+        sphinx-build -M html docs docs/_build -W
+        python scripts/gen-openapi
 
 [testenv:mypy]
 commands=


### PR DESCRIPTION
Similar to RHELDST-19887, sphinx-build cannot handle the openapi files copying to docs. Let's manually do the copying in the scripts/gen-openapi.