### PR TITLE
Fix searching for base rpms in debug repos [RHELDST-12605]

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -12,4 +12,3 @@ allowed_ubi_repo_groups = {"repo_group_prefix:foo":
                             "repo_3"
                             ]
                           }
-

--- a/docker/Dockerfile-broker
+++ b/docker/Dockerfile-broker
@@ -2,4 +2,4 @@ FROM redis
 
 EXPOSE 6379
 
-CMD [ "redis-server"]
+CMD ["redis-server"]

--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -232,7 +232,9 @@ def test_run(pulp):
     modular_filenames = set()
 
     with LogCapture() as mock_log:
-        with Depsolver([dep_item_1, dep_item_2], [repo_srpm], module_rpms, modular_filenames) as depsolver:
+        with Depsolver(
+            [dep_item_1, dep_item_2], [repo_srpm], module_rpms, modular_filenames
+        ) as depsolver:
             depsolver.run()
 
             # check internal state of depsolver object

--- a/tests/test_modulemd_depsolver.py
+++ b/tests/test_modulemd_depsolver.py
@@ -381,7 +381,7 @@ def _prepare_pulp(pulp):
     # Filter out .src modular rpms
     expected_modular_rpms = set(
         filter(
-            lambda x: not "not-in-profile" in x,
+            lambda x: not "not-in-profile" in x and ".src.rpm" not in x,
             modular_rpms,
         )
     )

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -253,10 +253,19 @@ def _get_population_sources(client, repo):
 
 
 def _run_depsolver(
-    depsolver_items, repos_map, in_source_rpm_repos, modulemd_deps, modular_rpm_filenames, flags
+    depsolver_items,
+    repos_map,
+    in_source_rpm_repos,
+    modulemd_deps,
+    modular_rpm_filenames,
+    flags,
 ):
     with Depsolver(
-        depsolver_items, in_source_rpm_repos, modulemd_deps, modular_rpm_filenames, **flags
+        depsolver_items,
+        in_source_rpm_repos,
+        modulemd_deps,
+        modular_rpm_filenames,
+        **flags,
     ) as depsolver:
         depsolver.run()
         exported = depsolver.export()

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -23,6 +23,7 @@ class ModularDepsolver:
     """
     Class for depsolving modulemd units
     """
+
     def __init__(self, modular_items: List[ModularDepsolverItem]) -> None:
         self._modular_items: List[ModularDepsolverItem] = modular_items
         self._input_repos: List[YumRepository] = list(

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -69,6 +69,7 @@ class Depsolver:
         """
         Search for modulemds in all input repos and extract rpm filenames.
         """
+
         def extract_modular_filenames():
             filenames = set()
             for module in modules:
@@ -85,7 +86,9 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpm_filenames)
+        newest_rpms = get_n_latest_from_content(
+            content, blacklist, self._modular_rpm_filenames
+        )
 
         return newest_rpms
 
@@ -149,7 +152,9 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpm_filenames)
+        newest_rpms = get_n_latest_from_content(
+            content, blacklist, self._modular_rpm_filenames
+        )
 
         return newest_rpms
 
@@ -183,7 +188,9 @@ class Depsolver:
 
         # Get modular rpms if they are not already populated from the previous run of the depsolver
         if not self._modular_rpm_filenames:
-            self._modular_rpm_filenames.update(self._get_pkgs_from_all_modules(pulp_repos))
+            self._modular_rpm_filenames.update(
+                self._get_pkgs_from_all_modules(pulp_repos)
+            )
 
         merged_blacklist = list(
             chain.from_iterable([repo.blacklist for repo in self.repos])
@@ -200,7 +207,7 @@ class Depsolver:
             for repo in self.repos
         ]
 
-        #Get modulemd binary/debug rpm dependencies
+        # Get modulemd binary/debug rpm dependencies
         if self.modulemd_dependencies:
             content_fts.append(
                 self._executor.submit(

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -35,6 +35,7 @@ class Depsolver:
         repos: List[DepsolverItem],
         srpm_repos,
         modulemd_dependencies: Set[str],
+        modular_rpm_filenames,
         **kwargs,
     ) -> None:
         self.repos: List[DepsolverItem] = repos
@@ -50,8 +51,8 @@ class Depsolver:
         # set of solvables (pkg, lib, ...) that we use for checking remaining requires
         self._unsolved: Set = set()
 
-        # Set of all modular rpms
-        self._modular_rpms: Set = set()
+        # Set of all modular rpms. Modifying the given modular_rpm_filenames set in place.
+        self._modular_rpm_filenames: Set = modular_rpm_filenames
 
         self._executor: ThreadPoolExecutor = Executors.thread_pool(
             max_workers=MAX_WORKERS
@@ -65,14 +66,15 @@ class Depsolver:
         self._executor.__exit__(*args, **kwargs)
 
     def _get_pkgs_from_all_modules(self, repos):
-        # search for modulemds in all input repos
-        # and extract filenames only
+        """
+        Search for modulemds in all input repos and extract rpm filenames.
+        """
         def extract_modular_filenames():
-            modular_rpm_filenames = set()
+            filenames = set()
             for module in modules:
-                modular_rpm_filenames |= set(module.artifacts_filenames)
+                filenames |= set(module.artifacts_filenames)
 
-            return modular_rpm_filenames
+            return filenames
 
         modules = search_modulemds([Criteria.true()], repos)
         return f_proxy(self._executor.submit(extract_modular_filenames))
@@ -83,12 +85,13 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpms)
+        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpm_filenames)
+
         return newest_rpms
 
     def get_modulemd_packages(self, repos, pkgs_list):
         """
-        Search for modulemd dependencies
+        Search for modular rpms.
         """
         crit = create_or_criteria(["filename"], [(rpm,) for rpm in pkgs_list])
 
@@ -146,7 +149,7 @@ class Depsolver:
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
-        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpms)
+        newest_rpms = get_n_latest_from_content(content, blacklist, self._modular_rpm_filenames)
 
         return newest_rpms
 
@@ -177,13 +180,16 @@ class Depsolver:
         pulp_repos = list(
             chain.from_iterable([repo.in_pulp_repos for repo in self.repos])
         )
-        # get modular rpms first
-        self._modular_rpms = self._get_pkgs_from_all_modules(pulp_repos)
+
+        # Get modular rpms if they are not already populated from the previous run of the depsolver
+        if not self._modular_rpm_filenames:
+            self._modular_rpm_filenames.update(self._get_pkgs_from_all_modules(pulp_repos))
 
         merged_blacklist = list(
             chain.from_iterable([repo.blacklist for repo in self.repos])
         )
-        # search for rpms
+
+        # search for base rpms
         content_fts = [
             self._executor.submit(
                 self.get_base_packages,
@@ -194,36 +200,18 @@ class Depsolver:
             for repo in self.repos
         ]
 
-        source_rpm_fts = []
-
+        #Get modulemd binary/debug rpm dependencies
         if self.modulemd_dependencies:
-            # Divide modular dependencies into binary and modular rpms
-            binary_modular_deps = set()
-            source_modular_deps = set()
-            for item in self.modulemd_dependencies:
-                if ".src.rpm" in item:
-                    source_modular_deps.add(item)
-                else:
-                    binary_modular_deps.add(item)
-
-            # Get moduelmd binary rpm dependencies
-            if binary_modular_deps:
-                content_fts.append(
-                    self._executor.submit(
-                        self.get_modulemd_packages, pulp_repos, binary_modular_deps
-                    )
+            content_fts.append(
+                self._executor.submit(
+                    self.get_modulemd_packages,
+                    pulp_repos,
+                    self.modulemd_dependencies,
                 )
+            )
 
-            # Get modulemd source rpm dependencies
-            if source_modular_deps:
-                source_rpm_fts.append(
-                    self._executor.submit(
-                        self.get_modulemd_packages,
-                        self._srpm_repos,
-                        source_modular_deps,
-                    )
-                )
-
+        # Get source rpms of found base packages and binary/debug modular packages
+        source_rpm_fts = []
         for content in as_completed(content_fts):
             self.output_set.update(content.result())
             ft = self._executor.submit(
@@ -237,26 +225,26 @@ class Depsolver:
         while True and not self._base_pkgs_only:
             # extract provides and requires
             self.extract_and_resolve(to_resolve)
-            # we are finished if _ensolved is empty
+            # we are finished if _unsolved is empty
             if not self._unsolved:
                 break
 
             batch = []
             # making batch as the query for provides.name in rpm units is slow in general
-            # we'll better do it is smaller batches
+            # we'll better do it in smaller batches
             for _ in range(self._batch_size()):
                 batch.append(self._unsolved.pop())
             # get new content that provides current batch of requires
             resolved = self.what_provides(batch, pulp_repos, merged_blacklist)
             # new content needs resolving deps
             to_resolve = set(resolved)
-            # add contetnt to the output set
+            # add content to the output set
             self.output_set.update(resolved)
             # submit query for source rpms
             ft = self._executor.submit(self.get_source_pkgs, resolved, merged_blacklist)
             source_rpm_fts.append(ft)
 
-        # wait for srpm queries and store them the output set
+        # wait for srpm queries and store them in the output set
         for srpm_content in as_completed(source_rpm_fts):
             for srpm in srpm_content.result():
                 self.srpm_output_set.add(srpm)


### PR DESCRIPTION
The depsolving of rpms is done in two runs, for binary and debug repos separately. Previously, in both of this runs the search for all modular filenames was done as well. However, this was useless for the run with debug repos, as they do not contain modulemd units (in which the modular rpm filenames are listed).
Also when updating modular `rpm_dependencies` in `modulemd_depsolver`, the intention (according to the docstring) was to omit source rpms, since they are searched for separately later in `rpm_depsolver`. But this was not happening.

This commit intends to fix this and make it more understandable by couple of changes:
- Pass the list of all modular filenames as an argument to the Depsolver. The list is then modified in place and therefore is populated from the binary repos on the first run.
- Make `update_rpm_dependencies` really skip source rpms and remove the unnecessary division of the rpm dependencies into source and binary from the depsolver, since we know there won't be any source rpms.
- Put the extension of `in_source_rpm_repos` before the iteration through cs_repo_map, since it should only be done once.
- Fix some typos, wrong comments.