### PR TITLE
Fix missing or wrong type annotations [RHELDST-19004]

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,9 @@
 name: Mypy check
 
-on: pull_request_target
+on:
+  pull_request:
+  push:
+    branches: master
 
 
 jobs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import ubiconfig
 from attrs import define
 from pubtools.pulplib import RpmDependency, YumRepository
@@ -83,7 +81,7 @@ class MockedRedis:
     def get(self, key: str) -> str:
         return self.data.get(key)
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         return list(self.data.keys())
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,33 +3,34 @@ envlist = py39,py310,py311
 isolated_build = true
 
 [testenv]
-commands=pytest -v {posargs}
-allowlist_externals=sh, poetry
+commands = pytest -v {posargs}
+allowlist_externals = sh, poetry
 skip_install = true
 commands_pre =
     poetry run pip -V
     poetry install --with dev,test
 
 [testenv:static]
-commands=
+commands =
 	black --check .
 	sh -c 'pylint ubi_manifest; test $(( $? & (1|2|4|32) )) = 0'
 
 [testenv:cov]
-usedevelop=true
-commands=
+usedevelop = true
+commands =
 	pytest --cov-report=html --cov-report=xml --cov=ubi_manifest --cov-fail-under=100 {posargs}
 
 [testenv:docs]
-use_develop=true
-commands=
+use_develop = true
+commands =
     poetry install --with docs
     sphinx-build -M html docs docs/_build -W
     python scripts/gen-openapi
 
 [testenv:mypy]
-commands=
-	sh -c 'mypy ubi_manifest'
+deps = types-redis
+commands =
+	sh -c 'mypy ubi_manifest --strict'
 
 [pytest]
 testpaths = tests

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -1,4 +1,5 @@
 import json
+
 import redis
 from fastapi import APIRouter, HTTPException
 

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -1,6 +1,4 @@
 import json
-from typing import List
-
 import redis
 from fastapi import APIRouter, HTTPException
 
@@ -13,13 +11,13 @@ router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/status")
-def status():
+def status() -> dict[str, str]:
     return {"status": "OK"}
 
 
 @router.post(
     "/manifest",
-    response_model=List[TaskState],
+    response_model=list[TaskState],
     status_code=201,
     responses={
         201: {
@@ -47,8 +45,8 @@ def status():
         },
     },
 )
-def manifest_post(depsolve_item: DepsolveItem) -> List[TaskState]:
-    repo_groups = {}
+def manifest_post(depsolve_item: DepsolveItem) -> list[TaskState]:
+    repo_groups: dict[str, list[str]] = {}
     # compare provided repo_ids with the config and pick allowed repo groups
     for repo_id in depsolve_item.repo_ids:
         for key, group in app.conf.allowed_ubi_repo_groups.items():
@@ -113,8 +111,8 @@ def manifest_get(repo_id: str) -> DepsolverResult:
     value = redis_client.get(repo_id) or ""
     if value:
         content = []
-        for value in json.loads(value):
-            item = DepsolverResultItem(**value)
+        for parsed_value in json.loads(value):
+            item = DepsolverResultItem(**parsed_value)
             content.append(item)
         result = DepsolverResult(repo_id=repo_id, content=content)
         return result

--- a/ubi_manifest/app/factory.py
+++ b/ubi_manifest/app/factory.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from ubi_manifest.app import api
 
 
-def create_app():
+def create_app() -> FastAPI:
     app = FastAPI()
     app.include_router(api.router)
 

--- a/ubi_manifest/app/models.py
+++ b/ubi_manifest/app/models.py
@@ -1,10 +1,8 @@
-from typing import List
-
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 
 class DepsolveItem(BaseModel):
-    repo_ids: List[str]
+    repo_ids: list[str]
 
 
 class TaskState(BaseModel):
@@ -21,4 +19,4 @@ class DepsolverResultItem(BaseModel):
 
 class DepsolverResult(BaseModel):
     repo_id: str
-    content: List[DepsolverResultItem]
+    content: list[DepsolverResultItem]

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -4,16 +4,16 @@ from collections import defaultdict
 from collections.abc import Iterable
 from concurrent.futures import Future
 from typing import Any
-from ubiconfig import UbiConfig
 
 import redis
 from pubtools.pulplib import (
+    Client,
     ModulemdDefaultsUnit,
     ModulemdUnit,
     RpmUnit,
-    Client,
     YumRepository,
 )
+from ubiconfig import UbiConfig
 
 from ubi_manifest.worker.tasks.celery import app
 from ubi_manifest.worker.tasks.depsolver.models import (

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -1,7 +1,7 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
 from attrs import define
-from pubtools.pulplib import YumRepository, Unit
+from pubtools.pulplib import Unit, YumRepository
 from ubiconfig.config_types.modules import Module
 
 

--- a/ubi_manifest/worker/tasks/depsolver/models.py
+++ b/ubi_manifest/worker/tasks/depsolver/models.py
@@ -1,7 +1,7 @@
-from typing import List, Set
+from typing import Optional, Any
 
 from attrs import define
-from pubtools.pulplib import YumRepository
+from pubtools.pulplib import YumRepository, Unit
 from ubiconfig.config_types.modules import Module
 
 
@@ -10,17 +10,17 @@ class UbiUnit:
     Wrapping class of model classes (*Unit) of pubtools.pulplib.
     """
 
-    def __init__(self, unit, src_repo_id):
+    def __init__(self, unit: Unit, src_repo_id: str):
         self._unit = unit
         self.associate_source_repo_id = src_repo_id
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._unit, name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self._unit)
 
-    def isinstance_inner_unit(self, klass):
+    def isinstance_inner_unit(self, klass: Unit) -> bool:
         return isinstance(self._unit, klass)
 
     # TODO make this return hash of self._unit if possible in future
@@ -35,18 +35,18 @@ class UbiUnit:
 class PackageToExclude:
     name: str
     globbing: bool = False
-    arch: str = None
+    arch: Optional[str] = None
 
 
 @define
 class DepsolverItem:
-    whitelist: Set[str]
-    blacklist: List[PackageToExclude]
-    in_pulp_repos: List[YumRepository]
+    whitelist: set[str]
+    blacklist: list[PackageToExclude]
+    in_pulp_repos: list[YumRepository]
 
 
 @define
 class ModularDepsolverItem:
-    modulelist: List[Module]
+    modulelist: list[Module]
     repo: YumRepository
-    in_pulp_repos: List[YumRepository]
+    in_pulp_repos: list[YumRepository]

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -2,13 +2,15 @@
 Module for depsolving modulemds in ubi repositories
 """
 from __future__ import annotations
+
 import logging
 import os
 from itertools import chain
 from typing import Any
+
 from more_executors import Executors
 from more_executors.futures import f_proxy
-from pubtools.pulplib import YumRepository, ModulemdUnit
+from pubtools.pulplib import ModulemdUnit, YumRepository
 
 from .models import ModularDepsolverItem, UbiUnit
 from .pulp_queries import search_modulemd_defaults, search_modulemds

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -1,14 +1,14 @@
 """
 Module for depsolving modulemds in ubi repositories
 """
+from __future__ import annotations
 import logging
 import os
 from itertools import chain
-from typing import Dict, List, Set
-
+from typing import Any
 from more_executors import Executors
 from more_executors.futures import f_proxy
-from pubtools.pulplib import YumRepository
+from pubtools.pulplib import YumRepository, ModulemdUnit
 
 from .models import ModularDepsolverItem, UbiUnit
 from .pulp_queries import search_modulemd_defaults, search_modulemds
@@ -24,9 +24,9 @@ class ModularDepsolver:
     Class for depsolving modulemd units
     """
 
-    def __init__(self, modular_items: List[ModularDepsolverItem]) -> None:
-        self._modular_items: List[ModularDepsolverItem] = modular_items
-        self._input_repos: List[YumRepository] = list(
+    def __init__(self, modular_items: list[ModularDepsolverItem]) -> None:
+        self._modular_items: list[ModularDepsolverItem] = modular_items
+        self._input_repos: list[YumRepository] = list(
             chain.from_iterable(item.in_pulp_repos for item in self._modular_items)
         )
         self._profiles = {}
@@ -43,25 +43,25 @@ class ModularDepsolver:
         )
 
         # set of all already searched modules to avoid duplication & cycles
-        self._searched_modules: Dict[str, Set[str]] = {
+        self._searched_modules: dict[str, set[str]] = {
             "without_stream": set(),
             "with_stream": set(),
         }
         # output set of resolved modulemd packages
-        self.modules: List[UbiUnit] = []
+        self.modules: list[UbiUnit] = []
         # output set of resolved modulemd defaults
-        self.default_modulemds: List[UbiUnit] = []
+        self.default_modulemds: list[UbiUnit] = []
         # set of binary and debuginfo rpm dependencies to be resolved
-        self.rpm_dependencies: Set(str) = set()
+        self.rpm_dependencies: set[str] = set()
 
-    def __enter__(self):
+    def __enter__(self) -> ModularDepsolver:
         self._executor.__enter__()
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
         self._executor.__exit__(*args, **kwargs)
 
-    def run(self):
+    def run(self) -> None:
         """
         Run depsolver for each moudular dependency - recursively resolve all of
         its modular dependencies and add binary and debug dependencies to list.
@@ -76,9 +76,9 @@ class ModularDepsolver:
                 )
             )
             # recurrently resolve dependencies for found modules
-            self._depsolve_modules(modules)
+            self._depsolve_modules(modules)  # type: ignore [arg-type]
 
-    def _depsolve_modules(self, modules):
+    def _depsolve_modules(self, modules: set[UbiUnit]) -> None:
         """
         Update modulemd output set with latest versions of modules, then find
         dependencies for the modules and depsolve them.
@@ -89,7 +89,7 @@ class ModularDepsolver:
         modules_to_search = []
         modulemd_defaults_criteria = get_criteria_for_modules(filtered_modules)
         self.default_modulemds.extend(
-            f_proxy(
+            f_proxy(  # type: ignore [arg-type]
                 self._executor.submit(
                     search_modulemd_defaults,
                     modulemd_defaults_criteria,
@@ -117,28 +117,28 @@ class ModularDepsolver:
                     search_modulemds, modulemds_criteria, self._input_repos
                 )
             )
-            self._depsolve_modules(new_modules)
+            self._depsolve_modules(new_modules)  # type: ignore [arg-type]
 
-    def _update_searched_modules(self, module):
+    def _update_searched_modules(self, module: ModulemdUnit) -> None:
         if module.stream is None:
             self._searched_modules["without_stream"].add(module.name)
         else:
             self._searched_modules["with_stream"].add(f"{module.name}:{module.stream}")
 
-    def _already_searched(self, module):
+    def _already_searched(self, module: ModulemdUnit) -> bool:
         """Returns True if the module has already been searched for"""
         return (
             module.name in self._searched_modules["without_stream"]
             or f"{module.name}:{module.stream}" in self._searched_modules["with_stream"]
         )
 
-    def _update_rpm_dependencies(self, module):
+    def _update_rpm_dependencies(self, module: UbiUnit) -> None:
         """
         Adds pkgs from module artifacts to rpm dependencies. Filters by profiles if available.
         Skips source packages since they are searched for separately in rpm_depsolver.
         """
         if module.artifacts:
-            pkg_names = []
+            pkg_names: list[str] = []
 
             if module.profiles:
                 key = f"{module.name}:{module.stream}"
@@ -157,10 +157,10 @@ class ModularDepsolver:
                 else:
                     self.rpm_dependencies.add(pkg)
 
-    def export(self) -> Dict[str, Dict[str, List[UbiUnit]]]:
+    def export(self) -> dict[str, Any]:
         """Returns a dictionary of depsolved modules and their rpm dependencies."""
-        out = {}
-        modules_out = {}
+        out: dict[str, Any] = {}
+        modules_out: dict[str, list[UbiUnit]] = {}
         nsvca_set = set()
         for module in self.modules:
             # filter duplicates

--- a/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
+++ b/ubi_manifest/worker/tasks/depsolver/pulp_queries.py
@@ -1,15 +1,16 @@
 import os
 from concurrent.futures import Future
 from typing import Optional
+
 from more_executors.futures import f_flat_map, f_map, f_proxy, f_return, f_sequence
 from pubtools.pulplib import (
     Criteria,
     ModulemdDefaultsUnit,
     ModulemdUnit,
-    RpmUnit,
-    YumRepository,
-    Unit,
     Page,
+    RpmUnit,
+    Unit,
+    YumRepository,
 )
 
 from .models import UbiUnit

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
 import logging
 import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from itertools import chain
-from typing import List, Set
-
+from typing import Any
 from more_executors import Executors
 from more_executors.futures import f_proxy
-from pubtools.pulplib import Criteria, YumRepository
+from pubtools.pulplib import Criteria, YumRepository, RpmDependency
 
+from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude
 from .models import DepsolverItem, UbiUnit
 from .pulp_queries import search_modulemds, search_rpms
 from .utils import (
@@ -17,6 +18,7 @@ from .utils import (
     is_requirement_resolved,
     parse_bool_deps,
 )
+
 
 _LOG = logging.getLogger(__name__)
 
@@ -32,47 +34,49 @@ MAX_WORKERS = int(os.getenv("UBI_MANIFEST_DEPSOLVER_WORKERS", "8"))
 class Depsolver:
     def __init__(
         self,
-        repos: List[DepsolverItem],
-        srpm_repos,
-        modulemd_dependencies: Set[str],
-        modular_rpm_filenames,
-        **kwargs,
+        repos: list[DepsolverItem],
+        srpm_repos: list[Future[YumRepository]],
+        modulemd_dependencies: set[str],
+        modular_rpm_filenames: set[str],
+        **kwargs: Any,
     ) -> None:
-        self.repos: List[DepsolverItem] = repos
-        self.modulemd_dependencies: Set[str] = modulemd_dependencies
-        self.output_set: Set[UbiUnit] = set()
-        self.srpm_output_set: Set[UbiUnit] = set()
+        self.repos: list[DepsolverItem] = repos
+        self.modulemd_dependencies: set[str] = modulemd_dependencies
+        self.output_set: set[UbiUnit] = set()
+        self.srpm_output_set: set[UbiUnit] = set()
 
-        self._srpm_repos: List[Future[YumRepository]] = srpm_repos
+        self._srpm_repos: list[Future[YumRepository]] = srpm_repos
 
-        self._provides: Set = set()  # set of all rpm.provides we've visited
-        self._requires: Set = set()  # set of all rpm.requires we've visited
+        self._provides: set[RpmDependency] = set()  # set of rpm.provides we've visited
+        self._requires: set[RpmDependency] = set()  # set of rpm.requires we've visited
 
         # set of solvables (pkg, lib, ...) that we use for checking remaining requires
-        self._unsolved: Set = set()
+        self._unsolved: set[RpmDependency] = set()
 
-        # Set of all modular rpms. Modifying the given modular_rpm_filenames set in place.
-        self._modular_rpm_filenames: Set = modular_rpm_filenames
+        # Set of all modular rpms. Modifying the given modular_rpm_filenames set in place
+        self._modular_rpm_filenames: set[str] = modular_rpm_filenames
 
-        self._executor: ThreadPoolExecutor = Executors.thread_pool(
+        self._executor: ThreadPoolExecutor = Executors.thread_pool(  # type: ignore [assignment]
             max_workers=MAX_WORKERS
         )
         self._base_pkgs_only = kwargs.get("base_pkgs_only") or False
 
-    def __enter__(self):
+    def __enter__(self) -> Depsolver:
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
         self._executor.__exit__(*args, **kwargs)
 
-    def _get_pkgs_from_all_modules(self, repos):
+    def _get_pkgs_from_all_modules(
+        self, repos: list[YumRepository]
+    ) -> Future[set[str]]:
         """
         Search for modulemds in all input repos and extract rpm filenames.
         """
 
-        def extract_modular_filenames():
+        def extract_modular_filenames() -> set[str]:
             filenames = set()
-            for module in modules:
+            for module in modules:  # type: ignore [attr-defined]
                 filenames |= set(module.artifacts_filenames)
 
             return filenames
@@ -80,19 +84,27 @@ class Depsolver:
         modules = search_modulemds([Criteria.true()], repos)
         return f_proxy(self._executor.submit(extract_modular_filenames))
 
-    def get_base_packages(self, repos, pkgs_list, blacklist):
+    def get_base_packages(
+        self,
+        repos: list[YumRepository],
+        pkgs_list: set[str],
+        blacklist: list[PackageToExclude],
+    ) -> list[UbiUnit]:
         crit = create_or_criteria(["name"], [(rpm,) for rpm in pkgs_list])
 
         content = f_proxy(
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
+
         newest_rpms = get_n_latest_from_content(
-            content, blacklist, self._modular_rpm_filenames
+            content, blacklist, self._modular_rpm_filenames  # type: ignore [arg-type]
         )
 
         return newest_rpms
 
-    def get_modulemd_packages(self, repos, pkgs_list):
+    def get_modulemd_packages(
+        self, repos: list[YumRepository], pkgs_list: set[str]
+    ) -> Future[Future[set[UbiUnit]]]:
         """
         Search for modular rpms.
         """
@@ -103,7 +115,7 @@ class Depsolver:
         )
         return content
 
-    def extract_and_resolve(self, content):
+    def extract_and_resolve(self, content: set[UbiUnit]) -> None:
         """
         Extracts provides and requires from content and sets internal
         state of self accordingly.
@@ -138,7 +150,12 @@ class Depsolver:
                     solved.add(req)
             self._unsolved -= solved
 
-    def what_provides(self, list_of_requires, repos, blacklist):
+    def what_provides(
+        self,
+        list_of_requires: list[RpmDependency],
+        repos: list[YumRepository],
+        blacklist: list[PackageToExclude],
+    ) -> list[UbiUnit]:
         """
         Get the latest rpms that provides requirements from list_of_requires in given repos
         """
@@ -153,12 +170,14 @@ class Depsolver:
             self._executor.submit(search_rpms, crit, repos, BATCH_SIZE_RPM)
         )
         newest_rpms = get_n_latest_from_content(
-            content, blacklist, self._modular_rpm_filenames
+            content, blacklist, self._modular_rpm_filenames  # type: ignore [arg-type]
         )
 
         return newest_rpms
 
-    def get_source_pkgs(self, binary_rpms, blacklist):
+    def get_source_pkgs(
+        self, binary_rpms: list[UbiUnit], blacklist: list[PackageToExclude]
+    ) -> set[UbiUnit]:
         crit = create_or_criteria(
             ["filename"], [(rpm.sourcerpm,) for rpm in binary_rpms if rpm.sourcerpm]
         )
@@ -169,9 +188,9 @@ class Depsolver:
             )
         )
 
-        return {rpm for rpm in content if not _is_blacklisted(rpm, blacklist)}
+        return {rpm for rpm in content if not _is_blacklisted(rpm, blacklist)}  # type: ignore [attr-defined]
 
-    def run(self):
+    def run(self) -> None:
         """
         Method runs whole depsolving machinery:
         1. Get base packages from each repo input - based on repo whitelist
@@ -189,7 +208,7 @@ class Depsolver:
         # Get modular rpms if they are not already populated from the previous run of the depsolver
         if not self._modular_rpm_filenames:
             self._modular_rpm_filenames.update(
-                self._get_pkgs_from_all_modules(pulp_repos)
+                self._get_pkgs_from_all_modules(pulp_repos)  # type: ignore [arg-type]
             )
 
         merged_blacklist = list(
@@ -211,7 +230,7 @@ class Depsolver:
         if self.modulemd_dependencies:
             content_fts.append(
                 self._executor.submit(
-                    self.get_modulemd_packages,
+                    self.get_modulemd_packages,  # type: ignore [arg-type]
                     pulp_repos,
                     self.modulemd_dependencies,
                 )
@@ -264,7 +283,7 @@ class Depsolver:
             if deps_not_found:
                 self._log_warnings(deps_not_found, pulp_repos, merged_blacklist)
 
-    def _batch_size(self):
+    def _batch_size(self) -> int:
         if len(self._unsolved) < BATCH_SIZE_RESOLVER:
             batch_size = len(self._unsolved)
         else:
@@ -272,10 +291,10 @@ class Depsolver:
 
         return batch_size
 
-    def export(self):
-        out = {}
+    def export(self) -> dict[str, list[UbiUnit]]:
+        out: dict[str, list[UbiUnit]] = {}
         # set of unique tuples (filename, repo_id)
-        filename_repo_tuples = set()
+        filename_repo_tuples: set[tuple[str, str]] = set()
         for item in self.output_set | self.srpm_output_set:
             # deduplicate output sets, but keep identical rpms that have different repository
             # we can't easily decide which one we should keep/discard.
@@ -290,7 +309,12 @@ class Depsolver:
 
         return out
 
-    def _log_warnings(self, deps_not_found, pulp_repos, merged_blacklist):
+    def _log_warnings(
+        self,
+        deps_not_found: set[str],
+        pulp_repos: list[YumRepository],
+        merged_blacklist: list[PackageToExclude],
+    ) -> None:
         """
         Log failed depsolving. We print out the rpms whose direct dependencies
         could not be included in output set.
@@ -298,12 +322,12 @@ class Depsolver:
         input_repos = [x.id for x in pulp_repos]
 
         # To determine if dep is missing due to being blacklisted
-        def _is_blacklisted_by_rule(item, rule):
+        def _is_blacklisted_by_rule(item: str, rule: PackageToExclude) -> bool:
             if rule.globbing:
                 return item.startswith(rule.name)
             return item == rule.name
 
-        def _requires_names(requires):
+        def _requires_names(requires: list[RpmDependency]) -> set[str]:
             out = set()
             for item in requires:
                 if item.name.startswith("("):
@@ -335,7 +359,7 @@ class Depsolver:
                     sorted(depending_rpms),
                 )
 
-    def _log_missing_base_pkgs(self):
+    def _log_missing_base_pkgs(self) -> None:
         found_pkg_names = {item.name for item in self.output_set}
 
         for item in self.repos:

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
+
 import logging
 import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from itertools import chain
 from typing import Any
+
 from more_executors import Executors
 from more_executors.futures import f_proxy
-from pubtools.pulplib import Criteria, YumRepository, RpmDependency
+from pubtools.pulplib import Criteria, RpmDependency, YumRepository
 
 from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude
+
 from .models import DepsolverItem, UbiUnit
 from .pulp_queries import search_modulemds, search_rpms
 from .utils import (
@@ -18,7 +21,6 @@ from .utils import (
     is_requirement_resolved,
     parse_bool_deps,
 )
-
 
 _LOG = logging.getLogger(__name__)
 

--- a/ubi_manifest/worker/tasks/depsolver/ubi_config.py
+++ b/ubi_manifest/worker/tasks/depsolver/ubi_config.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
 import ubiconfig
 

--- a/ubi_manifest/worker/tasks/depsolver/ubi_config.py
+++ b/ubi_manifest/worker/tasks/depsolver/ubi_config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Optional, Any
 
 import ubiconfig
 
@@ -10,17 +10,17 @@ class UbiConfigLoader:
 
     def __init__(self, url: str) -> None:
         self._url: str = url
-        self._config_map: dict = {}
-        self._all_config: List[ubiconfig.UbiConfig] = None
+        self._config_map: dict[tuple[str, str, str], ubiconfig.UbiConfig] = {}
+        self._all_config: Optional[list[ubiconfig.UbiConfig]] = None
 
     @property
-    def all_config(self) -> List[ubiconfig.UbiConfig]:
+    def all_config(self) -> list[ubiconfig.UbiConfig]:
         if self._all_config is None:
             self._all_config = self._load_all()
 
         return self._all_config
 
-    def _load_all(self) -> List[ubiconfig.UbiConfig]:
+    def _load_all(self) -> Any:
         loader = ubiconfig.get_loader(self._url)
         return loader.load_all()
 
@@ -46,7 +46,7 @@ class UbiConfigLoader:
         return out
 
     @staticmethod
-    def _content_sets(config: ubiconfig.UbiConfig) -> List[str]:
+    def _content_sets(config: ubiconfig.UbiConfig) -> list[tuple[str, str]]:
         return [
             (
                 config.content_sets.rpm.input,

--- a/ubi_manifest/worker/tasks/depsolver/utils.py
+++ b/ubi_manifest/worker/tasks/depsolver/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 import re
 from collections import defaultdict, deque
@@ -10,7 +11,6 @@ from pubtools.pulplib import Client, Criteria, Matcher, RpmDependency
 from ubiconfig import UbiConfig
 
 from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude, UbiUnit
-
 
 _LOG = getLogger(__name__)
 


### PR DESCRIPTION
There are a lot of `type: ignore` inline comments mainly because mypy does not check the type of the results of the Futures, but considers them to be of type `Future` , resulting in type incompatibility. Also this commit optimizes the function `_is_blacklisted()` so it is more clear and easier to type.