### PR TITLE
Fix the broken GitHub Action "Publish docs"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install Tox
-        run: pip install tox 'virtualenv<20.21.1'
+        run: pip install tox
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
       - name: Run Tox
         run: tox -e docs
       - name: Publish


### PR DESCRIPTION
"Publish docs" action is broken at the phase:
    docs: commands_pre[0]> poetry run pip -V

Since tox section docs is using poetry, let's add the poetry installation in the docs workflow file.
Also, remove the virtualenv version specification which is for the already removed dependency rpm-py-installer.