### PR TITLE
Pin the image version for rpm-libs matching python3.11-rpm [RHELDST-2…

### DIFF
--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311
+FROM registry.access.redhat.com/ubi9/python-311:1-41
 
 LABEL maintainer="Red Hat - EXD"
 
@@ -8,7 +8,7 @@ WORKDIR /src
 USER 0
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf install -y python3.11-rpm
+RUN dnf install -y python3.11-rpm-4.16.1.3-25.1.el9
 
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311
+FROM registry.access.redhat.com/ubi9/python-311:1-41
 
 LABEL maintainer="Red Hat - EXD"
 
@@ -9,7 +9,7 @@ USER 0
 
 # Enable CentOS repos, as rpm-devel is not in RHEL repos
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf install -y python3.11-rpm
+RUN dnf install -y python3.11-rpm-4.16.1.3-25.1.el9
 
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf


### PR DESCRIPTION
…2909]

The rpm-libs, which is a builtin package in the base image, is not matched the python3.11-rpm's installation requirement in the latest ubi9/python-311 image. And the image building will fail like this:

(app-root) dnf install -y python3.11-rpm
...

Error:
 Problem: conflicting requests
  - nothing provides (rpm-libs(x86-64) >= 4.16.1.3-25 with rpm-libs(x86-64) < 4.16.1.3-26) needed by python3.11-rpm-4.16.1.3-25.1.el9.x86_64 from epel (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

This commit pins the specific version of ubi9/python-311, which is using the right version of rpm-libs to match python3.11-rpm.