### PR TITLE
Fix the wrong site.addsitedir path

### DIFF
--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1-41
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 LABEL maintainer="Red Hat - EXD"
 
@@ -8,7 +8,7 @@ WORKDIR /src
 USER 0
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf install -y python3.11-rpm-4.16.1.3-25.1.el9
+RUN dnf install -y python3.11-rpm
 
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf
@@ -25,12 +25,13 @@ COPY . .
 RUN pip3.11 install poetry
 
 RUN poetry install --with server
-RUN python3 -c "import site; site.addsitedir('/usr/lib64/python3.11')"
-
 
 # Switch back to unpriviledged user to run the application
 USER 1001
 
 EXPOSE 8000
+
+# Add rpm module to site-packages
+RUN python -c "import site; site.addsitedir('/usr/lib64/python3.11/site-packages/')"
 
 CMD ["gunicorn", "--worker-class", "uvicorn.workers.UvicornWorker", "-w 4", "--config", "/src/conf/gunicorn.conf", "ubi_manifest.app.factory:create_app()"]

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1-41
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 LABEL maintainer="Red Hat - EXD"
 
@@ -9,7 +9,7 @@ USER 0
 
 # Enable CentOS repos, as rpm-devel is not in RHEL repos
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf install -y python3.11-rpm-4.16.1.3-25.1.el9
+RUN dnf install -y python3.11-rpm
 
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf
@@ -30,10 +30,11 @@ COPY . .
 RUN pip3.11 install poetry
 
 RUN poetry install
-RUN python3 -c "import site; site.addsitedir('/usr/lib64/python3.11')"
-
 
 # Switch back to unpriviledged user to run the application
 USER 1001
+
+# Add rpm module to site-packages
+RUN python -c "import site; site.addsitedir('/usr/lib64/python3.11/site-packages/')"
 
 CMD celery -A ubi_manifest.worker.tasks worker --loglevel=debug


### PR DESCRIPTION
The wrong site.addsitedir makes "import rpm" fail, it should use '/usr/lib64/python3.11/site-packages/' as the sitedir.