### PR TITLE
Reimplement allowed_repo_groups [RHELDST-22647]

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -5,10 +5,3 @@ pulp_password = x
 pulp_cert = x
 pulp_key = x
 content_config = {"repo_group_prefix": "url-to-config-repo"}
-allowed_ubi_repo_groups = {"repo_group_prefix:foo":
-                            [
-                            "repo_1",
-                            "repo_2",
-                            "repo_3"
-                            ]
-                          }

--- a/conf/gunicorn.conf
+++ b/conf/gunicorn.conf
@@ -1,5 +1,0 @@
-# Log requests to stdout
-accesslog = '-'
-
-# Export on 8000, which is exposed by the container image
-bind = '0.0.0.0:8000'

--- a/conf/gunicorn_conf.py
+++ b/conf/gunicorn_conf.py
@@ -1,0 +1,8 @@
+# Export on 8000, which is exposed by the container image
+bind = "0.0.0.0:8000"
+
+worker_class = "uvicorn.workers.UvicornWorker"
+
+workers = 4
+
+logconfig = "/src/conf/logging.ini"

--- a/conf/logging.ini
+++ b/conf/logging.ini
@@ -1,0 +1,38 @@
+[loggers]
+keys=root, gunicorn.error, gunicorn.access
+
+[handlers]
+keys=default, access
+
+[formatters]
+keys=default
+
+[logger_root]
+level=INFO
+handlers=default
+
+[logger_gunicorn.error]
+level=INFO
+handlers=default
+propagate=0
+qualname=gunicorn.error
+
+[logger_gunicorn.access]
+level=INFO
+handlers=access
+propagate=0
+qualname=gunicorn.access
+
+[handler_default]
+class=logging.StreamHandler
+formatter=default
+args=(sys.stderr, )
+
+[handler_access]
+class=logging.StreamHandler
+formatter=default
+args=(sys.stdout, )
+
+[formatter_default]
+format=%(asctime)s - [%(levelname)s] - [%(name)s/%(process)d] - %(message)s
+class=logging.Formatter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,13 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile-app
+    environment:
+      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
     command:
       - /bin/sh
       - -c
       - >-
-        uvicorn ubi_manifest.app.factory:create_app --factory --reload --host 0.0.0.0 --port 8000
+        uvicorn ubi_manifest.app.factory:create_app --factory --reload --host 0.0.0.0 --port 8000 --log-config /src/conf/logging.ini
     ports:
       - 8000:8000
     depends_on:

--- a/docker/Dockerfile-app
+++ b/docker/Dockerfile-app
@@ -10,6 +10,10 @@ USER 0
 # copy config
 COPY ./conf/app.conf /etc/ubi_manifest/app.conf
 
+# add certs for trusted connection dependent services if required
+COPY ./conf/certs/* /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust extract
+
 ENV POETRY_VERSION="1.7.0"\
     # Let poetry use the virtualenv that comes with the base image
     POETRY_VIRTUALENVS_CREATE=false\
@@ -30,4 +34,4 @@ USER 1001
 
 EXPOSE 8000
 
-CMD ["gunicorn", "--worker-class", "uvicorn.workers.UvicornWorker", "-w 4", "--config", "/src/conf/gunicorn.conf", "ubi_manifest.app.factory:create_app()"]
+CMD ["gunicorn", "ubi_manifest.app.factory:create_app()", "--config", "/src/conf/gunicorn_conf.py"]

--- a/tests/data/conf/test.conf
+++ b/tests/data/conf/test.conf
@@ -4,13 +4,6 @@ pulp_username = xxx
 pulp_password = yyy
 pulp_cert = path/to/pulp_cert
 pulp_key = path/to/pulp_key
-content_config = {"ubi": "https://gitlab.foo.bar.com/ubi-config"}
-allowed_ubi_repo_groups = {"ubiX:test":
-                            [
-                            "repo_1",
-                            "repo_2",
-                            "repo_3"
-                            ]
-                          }
+content_config = {"ubi": "https://gitlab.foo.bar.com/ubi-config", "client-tools": "https://gitlab.foo.bar.com/ct-config"}
 publish_limit = 2
 ubi_manifest_data_expiration = 4444

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,0 +1,119 @@
+import pytest
+from pubtools.pulplib import YumRepository
+from unittest.mock import patch, Mock
+
+from ubi_manifest.app import utils
+from .utils import create_and_insert_repo, create_mock_configs
+
+
+@pytest.mark.parametrize(
+    "repo_ids,expected_result",
+    [
+        (["ubi_repo1, ubi_repo2"], ["ubi"]),
+        (["ubi_repo, client-tools_repo"], ["ubi", "client-tools"]),
+        (["foreign_repo"], []),
+    ],
+)
+def test_get_repo_classes(repo_ids, expected_result):
+    content_config = {"ubi": "https://ubi", "client-tools": "https://ct"}
+    result = utils.get_repo_classes(content_config, repo_ids)
+    assert result == expected_result
+
+
+@patch("ubi_manifest.app.utils.ubiconfig.get_loader")
+@patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+def test_get_items_for_depsolving_default_groups(get_loader, pulp_client):
+    app_conf = Mock(
+        content_config={"ubi": "https://ubi", "client-tools": "https://ct"},
+        allowed_ubi_repo_groups={"ubi8:aarch64": ["ubi_repo1", "ubi_repo2"]},
+    )
+    result = utils.get_items_for_depsolving(app_conf, ["ubi_repo1"], "ubi")
+
+    assert result == [{"repo_group": ["ubi_repo1", "ubi_repo2"], "url": "https://ubi"}]
+    # Since the default allowed_repo_groups were defined in the app config, we do not need
+    # to call pulp or load any configs for the determination of the repo groups.
+    pulp_client.assert_not_called()
+    get_loader.assert_not_called()
+
+
+def test_get_items_from_groups():
+    repo_groups = {
+        "7-aarch64": {"ubi_repo1", "ubi_repo2", "ubi_repo3"},
+        "8-aarch64": {"ubi_repo4", "ubi_repo5", "ubi_repo6"},
+        "8-x86_64": {"ubi_repo7", "ubi_repo8", "ubi_repo9"},
+    }
+    repo_ids = ["ubi_repo4", "ubi_repo5", "ubi_repo9"]
+
+    result = utils.get_items_from_groups(repo_ids, repo_groups, "https://ubi")
+
+    assert result == [
+        {
+            "repo_group": ["ubi_repo4", "ubi_repo5", "ubi_repo6"],
+            "url": "https://ubi",
+        },
+        {
+            "repo_group": ["ubi_repo7", "ubi_repo8", "ubi_repo9"],
+            "url": "https://ubi",
+        },
+    ]
+
+
+@patch("ubiconfig.get_loader")
+def test_get_configs(get_loader):
+    conf1 = Mock(version="8")
+    conf2 = Mock(version="8.9")
+    get_loader.return_value = Mock(load_all=Mock(return_value=[conf1, conf2]))
+
+    result = utils.get_configs("https://ubi")
+    assert result == [conf1]
+
+
+def test_check_and_get_flag():
+    configs = create_mock_configs(2)
+    result = utils.check_and_get_flag(configs, "url")
+    assert result is False
+
+
+def test_check_and_get_flag_error():
+    configs = create_mock_configs(2, flags=[{}, {"base_pkgs_only": True}])
+    # 'base_pkg_only' flag is expected to have same value in all configs for one repo class
+    with pytest.raises(utils.FlagInconsistencyError):
+        utils.check_and_get_flag(configs, "url")
+
+
+def test_get_repo_groups(pulp):
+    configs = create_mock_configs(4)
+    create_and_insert_repo(
+        id="ubi8_repo1_for_aarch64",
+        content_set="content_set_0",
+        ubi_population=True,
+        arch="aarch64",
+        pulp=pulp,
+    )
+    create_and_insert_repo(
+        id="ubi8_repo2_for_aarch64",
+        content_set="content_set_1",
+        ubi_population=True,
+        arch="aarch64",
+        pulp=pulp,
+    )
+    create_and_insert_repo(
+        id="ubi8_repo3_for_aarch64",
+        content_set="content_set_2",
+        ubi_population=False,
+        arch="aarch64",
+        pulp=pulp,
+    )
+    create_and_insert_repo(
+        id="ubi8_repo1_for_x86_64",
+        content_set="content_set_3",
+        ubi_population=True,
+        arch="x86_64",
+        pulp=pulp,
+    )
+
+    result = utils.get_repo_groups(pulp.client, configs)
+    assert result == {
+        "8-aarch64": {"ubi8_repo1_for_aarch64", "ubi8_repo2_for_aarch64"},
+        "8-x86_64": {"ubi8_repo1_for_x86_64"},
+    }

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,8 +1,10 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from pubtools.pulplib import YumRepository
-from unittest.mock import patch, Mock
 
 from ubi_manifest.app import utils
+
 from .utils import create_and_insert_repo, create_mock_configs
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,11 +23,10 @@ def test_make_config():
         assert celery_app.conf["pulp_cert"] == "path/to/pulp_cert"
         assert celery_app.conf["pulp_key"] == "path/to/pulp_key"
         assert celery_app.conf["content_config"] == {
-            "ubi": "https://gitlab.foo.bar.com/ubi-config"
+            "ubi": "https://gitlab.foo.bar.com/ubi-config",
+            "client-tools": "https://gitlab.foo.bar.com/ct-config",
         }
-        assert celery_app.conf["allowed_ubi_repo_groups"] == {
-            "ubiX:test": ["repo_1", "repo_2", "repo_3"]
-        }
+        assert celery_app.conf["allowed_ubi_repo_groups"] == {}
 
         # check properly converted fields to int types
         assert celery_app.conf["publish_limit"] == 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import ubiconfig
 from attrs import define
+from unittest.mock import Mock
 from pubtools.pulplib import RpmDependency, YumRepository
 
 
@@ -8,6 +9,27 @@ def create_and_insert_repo(**kwargs):
     pulp.insert_repository(YumRepository(**kwargs))
 
     return pulp.client.get_repository(kwargs["id"])
+
+
+def create_mock_configs(n, flags=None, versions=None):
+    """
+    Creates n mock config objects with the given flags.
+    """
+    configs = []
+    if not flags:
+        flags = [{} for _i in range(n)]
+    if not versions:
+        versions = ["8" for _i in range(n)]
+
+    for i in range(n):
+        config = Mock(
+            version=versions[i],
+            flags=Mock(as_dict=Mock(return_value=flags[i])),
+            content_sets=Mock(rpm=Mock(output=f"content_set_{i}")),
+        )
+        configs.append(config)
+
+    return configs
 
 
 class MockLoader:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
+from unittest.mock import Mock
+
 import ubiconfig
 from attrs import define
-from unittest.mock import Mock
 from pubtools.pulplib import RpmDependency, YumRepository
 
 

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -1,0 +1,157 @@
+import logging
+
+from typing import Any
+
+import ubiconfig
+from pubtools.pulplib import Criteria, Client
+
+from ubi_manifest.worker.tasks.depsolver.utils import make_pulp_client
+
+
+_LOG = logging.getLogger(__name__)
+
+
+class FlagInconsistencyError(ValueError):
+    pass
+
+
+def get_repo_classes(content_config: dict[str, str], repo_ids: list[str]) -> list[str]:
+    """
+    Returns repo classes of repos for which the manifest creation was requested.
+    """
+    repo_classes = []
+    for repo_class in content_config:
+        for repo_id in repo_ids:
+            if repo_class in repo_id:
+                repo_classes.append(repo_class)
+                break
+
+    return repo_classes
+
+
+def get_items_for_depsolving(
+    app_conf: Any, repo_ids: list[str], repo_class: str
+) -> list[dict[str, Any]]:
+    """
+    Returns a list of {"repo_group": ["repo1", "repo2"], "url": "https://config"}
+    items which are then used for creation of depsolving tasks.
+    """
+    config_url = app_conf.content_config[repo_class]
+    if app_conf.allowed_ubi_repo_groups:
+        items = get_items_from_groups(
+            repo_ids, app_conf.allowed_ubi_repo_groups, config_url
+        )
+    else:
+        with make_pulp_client(app_conf) as client:
+            configs = get_configs(config_url)
+            base_pkg_only = check_and_get_flag(configs, config_url)
+            if base_pkg_only:
+                items = get_items_not_full_depsolving(
+                    client, configs, repo_ids, config_url
+                )
+            else:
+                repo_groups = get_repo_groups(client, configs)
+                items = get_items_from_groups(repo_ids, repo_groups, config_url)
+
+    _LOG.info("Determined items for depsolving: %s", items)
+    return items
+
+
+def get_items_from_groups(
+    repo_ids: list[str], repo_groups: dict[str, set[str]], config_url: str
+) -> list[dict[str, Any]]:
+    """
+    Returns a list of items for depsolving based on the given repo groups.
+    """
+    items: list[dict[str, Any]] = []
+    needed_repo_groups: dict[str, set[str]] = {}
+
+    for repo_id in repo_ids:
+        for group_key, repo_group in repo_groups.items():
+            if repo_id in repo_group:
+                needed_repo_groups.setdefault(group_key, repo_group)
+                break
+    # Create items for depsolving
+    for repo_group in needed_repo_groups.values():
+        items.append({"repo_group": list(sorted(repo_group)), "url": config_url})
+
+    return items
+
+
+def get_configs(url: str) -> Any:
+    """
+    Returns configs from the given url.
+    """
+    _LOG.info("Loading config from %s", url)
+
+    loader = ubiconfig.get_loader(url)
+    configs = loader.load_all()
+    # Use only configs for major versions
+    configs = [conf for conf in configs if "." not in conf.version]
+
+    return configs
+
+
+def check_and_get_flag(configs: list[Any], url: str) -> Any:
+    """
+    Checks if all given configs have the same value in the 'base_pkgs_only' flag
+    and returns that value if they do. Otherwise throws a FlagInconsistencyError.
+    """
+    flags = {config.flags.as_dict().get("base_pkgs_only", False) for config in configs}
+    if len(flags) != 1:
+        _LOG.error("Some config from %s has an unexpected 'base_pkg_only' flag.", url)
+        raise FlagInconsistencyError()
+
+    return list(flags)[0]
+
+
+def get_items_not_full_depsolving(
+    client: Client, configs: list[Any], repo_ids: list[str], config_url: str
+) -> list[dict[str, Any]]:
+    """
+    Returns a list of items for depsolving for repos where we don't use full depsolving.
+    Therefore no groups of repos need to be determined.
+    """
+    items: list[dict[str, Any]] = []
+    pulp_repo_ids = set()
+
+    # Get all repo ids from Pulp associated with the content sets from configs
+    for config in configs:
+        repos = get_repo_ids_from_cs(client, config.content_sets.rpm.output)
+        pulp_repo_ids.update({r.id for r in repos})
+    # Check that the provided repo ids are present among the repos from Pulp
+    # and create items for depsolving for each present repo
+    for repo_id in repo_ids:
+        if repo_id in pulp_repo_ids:
+            items.append({"repo_group": [repo_id], "url": config_url})
+    return items
+
+
+def get_repo_groups(client: Client, configs: list[Any]) -> dict[str, set[str]]:
+    """
+    Determines the allowed repo groups based on the the available ubi config and Pulp data.
+    """
+    repo_groups: dict[str, set[str]] = {}
+
+    for config in configs:
+        repos = get_repo_ids_from_cs(client, config.content_sets.rpm.output)
+        for repo in repos:
+            # Create groups by version and architecture
+            group_key = f"{config.version}-{repo.arch}"
+            repo_groups.setdefault(group_key, set()).add(repo.id)
+
+    return repo_groups
+
+
+def get_repo_ids_from_cs(client: Client, ubi_binary_cs: str) -> Any:
+    """
+    Returns a list of YumRepositories associated with the given content set
+    and which have the ubi_population note set to True.
+    """
+    repos = client.search_repository(
+        Criteria.and_(
+            Criteria.with_field("notes.content_set", ubi_binary_cs),
+            Criteria.with_field("ubi_population", True),
+        )
+    )
+    return repos

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -1,12 +1,10 @@
 import logging
-
 from typing import Any
 
 import ubiconfig
-from pubtools.pulplib import Criteria, Client
+from pubtools.pulplib import Client, Criteria
 
 from ubi_manifest.worker.tasks.depsolver.utils import make_pulp_client
-
 
 _LOG = logging.getLogger(__name__)
 

--- a/ubi_manifest/worker/tasks/celery.py
+++ b/ubi_manifest/worker/tasks/celery.py
@@ -1,6 +1,13 @@
 import celery
-
+from typing import Any
 from ubi_manifest.worker.tasks.config import make_config
 
 app = celery.Celery()
 make_config(app)
+
+
+@celery.signals.celeryd_init.connect  # type: ignore [misc]  # ignore untyped decorator
+def setup_log_format(conf: Any, **_kwargs: Any) -> None:  # pragma: no cover
+    conf.worker_log_format = (
+        "%(asctime)s - [%(levelname)s] - [%(name)s/%(process)d] - %(message)s"
+    )

--- a/ubi_manifest/worker/tasks/celery.py
+++ b/ubi_manifest/worker/tasks/celery.py
@@ -1,5 +1,7 @@
-import celery
 from typing import Any
+
+import celery
+
 from ubi_manifest.worker.tasks.config import make_config
 
 app = celery.Celery()

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -16,14 +16,12 @@ class Config:
     pulp_cert: str = "path/to/cert"
     pulp_key: str = "path/to/key"
     pulp_verify: Union[bool, str] = True
-    content_config: dict[str, str] = {"group_prefix": "url_or_dir"}
-    allowed_ubi_repo_groups: dict[str, list[str]] = {
-        "group_prefix1": ["repo_1", "repo_2"]
+    content_config: dict[str, str] = {
+        "ubi": "url_or_dir_1",
+        "client-tools": "url_or_dir_2",
     }
-    imports: list[str] = [
-        "ubi_manifest.worker.tasks.depsolve",
-        "ubi_manifest.worker.tasks.repo_monitor",
-    ]
+    allowed_ubi_repo_groups: dict[str, list[str]] = {}
+    imports: list[str] = ["ubi_manifest.worker.tasks.depsolve"]
     broker_url: str = "redis://redis:6379/0"
     result_backend: str = "redis://redis:6379/0"
     # 4 hours default data expiration for redis
@@ -47,7 +45,7 @@ def make_config(celery_app: celery.Celery) -> None:
     try:
         conf_dict: dict[str, Any] = dict(config_from_file["CONFIG"])
         for conf_field in ("allowed_ubi_repo_groups", "content_config"):
-            conf_item_str = config_from_file["CONFIG"].pop(conf_field) or ""
+            conf_item_str = config_from_file["CONFIG"].pop(conf_field, "{}")
             conf_item = json.loads(re.sub(r"[\s]+", "", conf_item_str))
             conf_dict[conf_field] = conf_item
 


### PR DESCRIPTION
Previously, repo groups for depsolving were hardcoded, often requiring manual updating. This commit introduces  the use of current data from ubi configs and pulp to determine these groups.

It also changes logging configurations:
- adds loging.ini configuration file needed to properly log events from the app while repo groups are being determined
- override celery worker_log_format so that all logs from app and workers are in the same format

Finally, it moves all of the gunicorn parameters into the gunicorn.conf file so that they're all in the same place and the command to run it is not so long.