### PR TITLE
Fix integer conf. items [RHELDST-13954]

### DIFF
--- a/tests/data/conf/test.conf
+++ b/tests/data/conf/test.conf
@@ -12,3 +12,5 @@ allowed_ubi_repo_groups = {"ubiX:test":
                             "repo_3"
                             ]
                           }
+publish_limit = 2
+ubi_manifest_data_expiration = 4444

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,3 +28,7 @@ def test_make_config():
         assert celery_app.conf["allowed_ubi_repo_groups"] == {
             "ubiX:test": ["repo_1", "repo_2", "repo_3"]
         }
+
+        # check properly converted fields to int types
+        assert celery_app.conf["publish_limit"] == 2
+        assert celery_app.conf["ubi_manifest_data_expiration"] == 4444

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -5,7 +5,7 @@ import re
 from typing import Any, Union
 
 import celery
-from attrs import define
+from attrs import define, field
 
 
 @define
@@ -26,10 +26,9 @@ class Config:
     ]
     broker_url: str = "redis://redis:6379/0"
     result_backend: str = "redis://redis:6379/0"
-    ubi_manifest_data_expiration: int = (
-        60 * 60 * 4
-    )  # 4 hours default data expiration for redis
-    publish_limit: int = 6  # in hours
+    # 4 hours default data expiration for redis
+    ubi_manifest_data_expiration: int = field(converter=int, default=60 * 60 * 4)
+    publish_limit: int = field(converter=int, default=6)  # in hours
     beat_schedule: dict[str, dict[str, Any]] = {
         "monitor-repo-every-N-hours": {
             "task": "ubi_manifest.worker.tasks.repo_monitor.repo_monitor_task",


### PR DESCRIPTION
Previously configuration items that are used and integeres were not converted to int type when user passed custom value via config file. Now `publish_limit` and `ubi_manifest_data_expiration` are now converted autoamtically to integers.