### PR TITLE
Reorganize worker code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,4 +5,7 @@ disable=fixme,
         missing-module-docstring,
         too-many-locals,
         too-many-branches,
+        too-many-instance-attributes,
+        too-many-statements,
+        too-many-arguments,
         

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -133,7 +133,7 @@ def test_manifest_get_not_found(client):
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_full_dep(
     mocked_apply_async, pulp_client, get_loader, client, pulp
@@ -196,7 +196,7 @@ def test_manifest_post_full_dep(
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_not_full_dep(
     mocked_apply_async, pulp_client, get_loader, client, pulp
@@ -251,7 +251,7 @@ def test_manifest_post_not_full_dep(
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_no_depsolve_items(
     mocked_apply_async, pulp_client, get_loader, client, pulp
@@ -287,7 +287,7 @@ def test_manifest_post_no_depsolve_items(
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_more_repo_classes(
     mocked_apply_async, pulp_client, get_loader, client
@@ -314,7 +314,7 @@ def test_manifest_post_more_repo_classes(
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_wrong_repo_ids(
     mocked_apply_async, pulp_client, get_loader, client
@@ -338,7 +338,7 @@ def test_manifest_post_wrong_repo_ids(
 
 
 @mock.patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@mock.patch("ubi_manifest.worker.utils.Client")
 @mock.patch("celery.app.task.Task.apply_async")
 def test_manifest_post_no_repo_ids(mocked_apply_async, pulp_client, get_loader, client):
     """test request for depsolving for empty list of repo ids"""

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -23,7 +23,7 @@ def test_get_repo_classes(repo_ids, expected_result):
 
 
 @patch("ubi_manifest.app.utils.ubiconfig.get_loader")
-@patch("ubi_manifest.worker.tasks.depsolver.utils.Client")
+@patch("ubi_manifest.worker.utils.Client")
 def test_get_items_for_depsolving_default_groups(get_loader, pulp_client):
     app_conf = Mock(
         content_config={"ubi": "https://ubi", "client-tools": "https://ct"},

--- a/tests/test_content_audit_task.py
+++ b/tests/test_content_audit_task.py
@@ -219,7 +219,7 @@ def test_content_audit_outdated(pulp, caplog):
         [rpm_1, rpm_2, module_1, module_2, default_1, default_2],
     )
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             client.return_value = pulp.client
 
@@ -288,7 +288,7 @@ def test_content_audit_blacklisted(pulp, caplog):
     pulp.insert_units(bad_repo, [blacklisted])
     pulp.insert_units(ubi_repo, [blacklisted])
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             client.return_value = pulp.client
 

--- a/tests/test_depsolve_task.py
+++ b/tests/test_depsolve_task.py
@@ -6,6 +6,7 @@ import pytest
 from pubtools.pulplib import Distributor, ModulemdDefaultsUnit, ModulemdUnit, RpmUnit
 
 from ubi_manifest.worker.tasks import depsolve
+from ubi_manifest.worker.ubi_config import ContentConfigMissing
 
 from .utils import MockedRedis, MockLoader, create_and_insert_repo
 
@@ -173,7 +174,7 @@ def test_depsolve_task(pulp):
     pulp.insert_units(rhel_debug_repo, [unit_debuginfo, unit_debugsource])
     pulp.insert_units(rhel_source_repo, [unit_srpm, unit_srpm_debug])
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             with mock.patch(
                 "ubi_manifest.worker.tasks.depsolve.redis.from_url"
@@ -326,7 +327,7 @@ def test_depsolve_task_empty_manifests(pulp):
         id="rhel_source_repo", pulp=pulp, content_set="cs_srpm_in"
     )
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             with mock.patch(
                 "ubi_manifest.worker.tasks.depsolve.redis.from_url"
@@ -767,7 +768,7 @@ def test_multiple_population_sources(pulp):
     """
     _setup_data_multiple_population_sources(pulp)
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             with mock.patch(
                 "ubi_manifest.worker.tasks.depsolve.redis.from_url"
@@ -873,7 +874,7 @@ def test_missing_content_config(pulp):
     """Exception is raised where there is no matching ubi content config"""
     _setup_repos_missing_config(pulp)
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch("ubiconfig.get_loader", return_value=MockLoader()):
             with mock.patch(
                 "ubi_manifest.worker.tasks.depsolve.redis.from_url"
@@ -883,7 +884,7 @@ def test_missing_content_config(pulp):
 
                 client.return_value = pulp.client
                 # let run the depsolve task
-                with pytest.raises(depsolve.ContentConfigMissing):
+                with pytest.raises(ContentConfigMissing):
                     _ = depsolve.depsolve_task(["ubi_repo"], "fake-url")
 
 
@@ -963,7 +964,7 @@ def _setup_repos_missing_config(pulp):
 def test_multiple_population_sources_skip_depsolving(pulp):
     _setup_data_multiple_population_sources(pulp)
 
-    with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+    with mock.patch("ubi_manifest.worker.utils.Client") as client:
         with mock.patch(
             "ubiconfig.get_loader",
             return_value=MockLoader(flags={"base_pkgs_only": True}),

--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -1,15 +1,9 @@
 from pubtools.pulplib import Distributor, ModulemdUnit, RpmDependency, RpmUnit
 from testfixtures import LogCapture
 
-from ubi_manifest.worker.tasks.depsolver.models import (
-    DepsolverItem,
-    PackageToExclude,
-    UbiUnit,
-)
-from ubi_manifest.worker.tasks.depsolver.rpm_depsolver import (
-    Depsolver,
-    get_pkgs_from_all_modules,
-)
+from ubi_manifest.worker.common import get_pkgs_from_all_modules
+from ubi_manifest.worker.models import DepsolverItem, PackageToExclude, UbiUnit
+from ubi_manifest.worker.tasks.depsolver import Depsolver
 
 from .utils import create_and_insert_repo, rpmdeps_from_names
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from pubtools.pulplib import RpmUnit
 
-from ubi_manifest.worker.tasks.depsolver.models import UbiUnit
+from ubi_manifest.worker.models import UbiUnit
 
 
 def test_ubi_unit():

--- a/tests/test_modulemd_depsolver.py
+++ b/tests/test_modulemd_depsolver.py
@@ -10,7 +10,7 @@ from pubtools.pulplib import (
 )
 from ubiconfig.config_types.modules import Module
 
-from ubi_manifest.worker.tasks.depsolver.models import (
+from ubi_manifest.worker.models import (
     DepsolverItem,
     ModularDepsolverItem,
     PackageToExclude,

--- a/tests/test_pulp_queries.py
+++ b/tests/test_pulp_queries.py
@@ -3,17 +3,14 @@ from tempfile import NamedTemporaryFile
 from attrs import define
 from pubtools.pulplib import Client, ModulemdUnit, RpmUnit, YumRepository
 
-from ubi_manifest.worker.tasks.depsolver.models import UbiUnit
-from ubi_manifest.worker.tasks.depsolver.pulp_queries import (
+from ubi_manifest.worker.models import UbiUnit
+from ubi_manifest.worker.pulp_queries import (
     _search_units_per_repos,
     search_modulemds,
     search_rpms,
     search_units,
 )
-from ubi_manifest.worker.tasks.depsolver.utils import (
-    create_or_criteria,
-    make_pulp_client,
-)
+from ubi_manifest.worker.utils import create_or_criteria, make_pulp_client
 
 from .utils import create_and_insert_repo
 

--- a/tests/test_repo_monitor_task.py
+++ b/tests/test_repo_monitor_task.py
@@ -55,7 +55,7 @@ def test_repo_monitor_task(pulp, caplog):
     with caplog.at_level(
         logging.DEBUG, logger="ubi_manifest.worker.tasks.repo_monitor"
     ):
-        with mock.patch("ubi_manifest.worker.tasks.depsolver.utils.Client") as client:
+        with mock.patch("ubi_manifest.worker.utils.Client") as client:
             client.return_value = pulp.client
             # let run the repo_monitor task
             result = repo_monitor.repo_monitor_task()

--- a/tests/test_ubi_config.py
+++ b/tests/test_ubi_config.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from ubi_manifest.worker.tasks.depsolver.ubi_config import UbiConfigLoader
+from ubi_manifest.worker.ubi_config import UbiConfigLoader
 
 from .utils import MockLoader
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,9 +10,9 @@ from pubtools.pulplib import (
     RpmUnit,
 )
 
-from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude, UbiUnit
-from ubi_manifest.worker.tasks.depsolver.ubi_config import UbiConfigLoader
-from ubi_manifest.worker.tasks.depsolver.utils import (
+from ubi_manifest.worker.models import PackageToExclude, UbiUnit
+from ubi_manifest.worker.ubi_config import UbiConfigLoader
+from ubi_manifest.worker.utils import (
     create_or_criteria,
     flatten_list_of_sets,
     get_criteria_for_modules,

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -4,7 +4,7 @@ from typing import Any
 import ubiconfig
 from pubtools.pulplib import Client, Criteria
 
-from ubi_manifest.worker.tasks.depsolver.utils import make_pulp_client
+from ubi_manifest.worker.utils import make_pulp_client
 
 _LOG = logging.getLogger(__name__)
 

--- a/ubi_manifest/worker/common.py
+++ b/ubi_manifest/worker/common.py
@@ -1,0 +1,44 @@
+from pubtools.pulplib import Criteria, YumRepository
+from ubiconfig import UbiConfig
+
+from ubi_manifest.worker.models import PackageToExclude
+from ubi_manifest.worker.pulp_queries import search_modulemds
+from ubi_manifest.worker.utils import is_blacklisted
+
+
+def filter_whitelist(
+    ubi_config: UbiConfig, blacklist: list[PackageToExclude]
+) -> tuple[set[str], set[str]]:
+    """
+    Produce whitelist and debuginfo_whitelist, filtering out src and blacklisted packages.
+    """
+    whitelist = set()
+    debuginfo_whitelist = set()
+
+    for pkg in ubi_config.packages.whitelist:
+        if pkg.arch == "src":
+            continue
+        if is_blacklisted(pkg, blacklist):
+            continue
+        if pkg.name.endswith("debuginfo") or pkg.name.endswith("debugsource"):
+            debuginfo_whitelist.add(pkg.name)
+        else:
+            whitelist.add(pkg.name)
+
+    return whitelist, debuginfo_whitelist
+
+
+def get_pkgs_from_all_modules(repos: list[YumRepository]) -> set[str]:
+    """
+    Search for modulemds in all input repos and extract rpm filenames.
+    """
+
+    def extract_modular_filenames() -> set[str]:
+        filenames = set()
+        for module in modules:  # type: ignore [attr-defined]
+            filenames |= set(module.artifacts_filenames)
+
+        return filenames
+
+    modules = search_modulemds([Criteria.true()], repos)
+    return extract_modular_filenames()

--- a/ubi_manifest/worker/models.py
+++ b/ubi_manifest/worker/models.py
@@ -21,6 +21,9 @@ class UbiUnit:
         return str(self._unit)
 
     def isinstance_inner_unit(self, klass: Unit) -> bool:
+        """
+        Compares type of unit given to type of unit this UbiUnit was derived from.
+        """
         return isinstance(self._unit, klass)
 
     def __hash__(self) -> int:
@@ -36,6 +39,9 @@ class UbiUnit:
 
 @define
 class PackageToExclude:
+    """
+    Representation of a excluded/blacklisted package.
+    """
     name: str
     globbing: bool = False
     arch: Optional[str] = None
@@ -43,6 +49,9 @@ class PackageToExclude:
 
 @define
 class DepsolverItem:
+    """
+    Item for resolution by RPM depsolver.
+    """
     whitelist: set[str]
     blacklist: list[PackageToExclude]
     in_pulp_repos: list[YumRepository]
@@ -50,6 +59,9 @@ class DepsolverItem:
 
 @define
 class ModularDepsolverItem:
+    """
+    Item for resolution by modulemd depsolver.
+    """
     modulelist: list[Module]
     repo: YumRepository
     in_pulp_repos: list[YumRepository]

--- a/ubi_manifest/worker/models.py
+++ b/ubi_manifest/worker/models.py
@@ -42,6 +42,7 @@ class PackageToExclude:
     """
     Representation of a excluded/blacklisted package.
     """
+
     name: str
     globbing: bool = False
     arch: Optional[str] = None
@@ -52,6 +53,7 @@ class DepsolverItem:
     """
     Item for resolution by RPM depsolver.
     """
+
     whitelist: set[str]
     blacklist: list[PackageToExclude]
     in_pulp_repos: list[YumRepository]
@@ -62,6 +64,7 @@ class ModularDepsolverItem:
     """
     Item for resolution by modulemd depsolver.
     """
+
     modulelist: list[Module]
     repo: YumRepository
     in_pulp_repos: list[YumRepository]

--- a/ubi_manifest/worker/pulp_queries.py
+++ b/ubi_manifest/worker/pulp_queries.py
@@ -13,8 +13,8 @@ from pubtools.pulplib import (
     YumRepository,
 )
 
-from .models import UbiUnit
-from .utils import flatten_list_of_sets
+from ubi_manifest.worker.models import UbiUnit
+from ubi_manifest.worker.utils import flatten_list_of_sets
 
 BATCH_SIZE = int(os.getenv("UBI_MANIFEST_BATCH_SIZE", "250"))
 
@@ -104,6 +104,9 @@ def search_modulemds(
     repos: list[YumRepository],
     batch_size_override: Optional[int] = None,
 ) -> Future[set[UbiUnit]]:
+    """
+    Execute a query for modulemd units matching given criteria.
+    """
     return _search_units_per_repos(
         or_criteria,
         repos,
@@ -117,6 +120,9 @@ def search_rpms(
     repos: list[YumRepository],
     batch_size_override: Optional[int] = None,
 ) -> Future[set[UbiUnit]]:
+    """
+    Execute a query for RPM units matching given criteria.
+    """
     return _search_units_per_repos(
         or_criteria,
         repos,
@@ -130,6 +136,9 @@ def search_modulemd_defaults(
     repos: list[YumRepository],
     batch_size_override: Optional[int] = None,
 ) -> Future[set[UbiUnit]]:
+    """
+    Execute a query for modulemd defaults units matching given criteria.
+    """
     return _search_units_per_repos(
         or_criteria,
         repos,

--- a/ubi_manifest/worker/tasks/content_audit.py
+++ b/ubi_manifest/worker/tasks/content_audit.py
@@ -6,13 +6,12 @@ from typing import Any
 from more_executors.futures import f_proxy
 from pubtools.pulplib import Criteria, ModulemdDefaultsUnit, ModulemdUnit, RpmUnit
 
+from ubi_manifest.worker.common import filter_whitelist, get_pkgs_from_all_modules
+from ubi_manifest.worker.models import PackageToExclude, UbiUnit
+from ubi_manifest.worker.pulp_queries import search_units
 from ubi_manifest.worker.tasks.celery import app
-from ubi_manifest.worker.tasks.depsolve import filter_whitelist, get_content_config
-from ubi_manifest.worker.tasks.depsolver.models import PackageToExclude, UbiUnit
-from ubi_manifest.worker.tasks.depsolver.pulp_queries import search_units
-from ubi_manifest.worker.tasks.depsolver.rpm_depsolver import get_pkgs_from_all_modules
-from ubi_manifest.worker.tasks.depsolver.ubi_config import UbiConfigLoader
-from ubi_manifest.worker.tasks.depsolver.utils import (
+from ubi_manifest.worker.ubi_config import UbiConfigLoader, get_content_config
+from ubi_manifest.worker.utils import (
     RELATION_CMP_MAP,
     create_or_criteria,
     get_criteria_for_modules,

--- a/ubi_manifest/worker/tasks/depsolver/__init__.py
+++ b/ubi_manifest/worker/tasks/depsolver/__init__.py
@@ -1,0 +1,4 @@
+from .modulemd_depsolver import ModularDepsolver
+from .rpm_depsolver import Depsolver
+
+__all__ = ["Depsolver", "ModularDepsolver"]

--- a/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/modulemd_depsolver.py
@@ -4,7 +4,6 @@ Module for depsolving modulemds in ubi repositories
 
 from __future__ import annotations
 
-import logging
 import os
 from itertools import chain
 from typing import Any
@@ -13,11 +12,13 @@ from more_executors import Executors
 from more_executors.futures import f_proxy
 from pubtools.pulplib import ModulemdUnit, YumRepository
 
-from .models import ModularDepsolverItem, UbiUnit
-from .pulp_queries import search_modulemd_defaults, search_modulemds
-from .utils import get_criteria_for_modules, get_modulemd_output_set, split_filename
-
-_LOG = logging.getLogger(__name__)
+from ubi_manifest.worker.models import ModularDepsolverItem, UbiUnit
+from ubi_manifest.worker.pulp_queries import search_modulemd_defaults, search_modulemds
+from ubi_manifest.worker.utils import (
+    get_criteria_for_modules,
+    get_modulemd_output_set,
+    split_filename,
+)
 
 MAX_WORKERS = int(os.getenv("UBI_MANIFEST_MODULAR_DEPSOLVER_WORKERS", "8"))
 

--- a/ubi_manifest/worker/tasks/repo_monitor.py
+++ b/ubi_manifest/worker/tasks/repo_monitor.py
@@ -6,7 +6,7 @@ from typing import Union
 from pubtools.pulplib import Criteria, Repository
 
 from ubi_manifest.worker.tasks.celery import app
-from ubi_manifest.worker.tasks.depsolver.utils import make_pulp_client
+from ubi_manifest.worker.utils import make_pulp_client
 
 _LOG = logging.getLogger(__name__)
 

--- a/ubi_manifest/worker/ubi_config.py
+++ b/ubi_manifest/worker/ubi_config.py
@@ -3,6 +3,12 @@ from typing import Any, Optional
 import ubiconfig
 
 
+class ContentConfigMissing(Exception):
+    """
+    Specific exception used when content configuration is missing.
+    """
+
+
 class UbiConfigLoader:
     """
     Class capable of loading UbiConfig from git repository at given url.
@@ -15,6 +21,9 @@ class UbiConfigLoader:
 
     @property
     def all_config(self) -> list[ubiconfig.UbiConfig]:
+        """
+        A list of all configurations loaded from UbiConfigLoader's url/dir.
+        """
         if self._all_config is None:
             self._all_config = self._load_all()
 
@@ -64,3 +73,22 @@ class UbiConfigLoader:
                 config.content_sets.srpm.output,
             ),
         ]
+
+
+def get_content_config(
+    ubi_config_loader: UbiConfigLoader, input_cs: str, output_cs: str, version: str
+) -> ubiconfig.UbiConfig:
+    """
+    Gets proper ubi_config for given input and output content sets and version,
+    falling back to default version if there is no match for requested config.
+    """
+    out = None
+    for _ver in (version, version.split(".")[0]):
+        out = ubi_config_loader.get_config(input_cs, output_cs, _ver)
+        if out:
+            break
+
+    if out is None:
+        raise ContentConfigMissing
+
+    return out


### PR DESCRIPTION
Previously modules outside of worker/tasks/depsolver/, with no relation to the depsolving process, reused code from inside depsolve module and depsolver directory. This change moves these common modules and functions out to the worker directory where they can be more appropriately accessed by non-depsolve tasks.

Additionally, reformatting was applied to touched files and mypy complaints addressed.