### PR TITLE
content-audit: fix modular RPM comparisons again [RHELDST-13955]

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,7 +44,11 @@ class MockLoader:
                     {
                         "name": "fake_name",
                         "stream": "fake_stream",
-                    }
+                    },
+                    {  # This should not be reported as missing in content audit tests.
+                        "name": "bind",
+                        "stream": "12",
+                    },
                 ]
             },
             "packages": {


### PR DESCRIPTION
Fitering input RPMs by modular filenames alone was not enough to prevent them from being compared. Also, seen modular RPMs included by module configuration were still listed as missing whitelisted content.

This change adds an additional modular check for output RPMs and ensures that seen modular input RPMs are added to `seen_modules` so they may be checked off from whitelist.