### PR TITLE
content audit: skip modules for debug,source repos [RHELDST-13955]

### DIFF
--- a/tests/test_content_audit_task.py
+++ b/tests/test_content_audit_task.py
@@ -255,7 +255,6 @@ def test_content_audit_outdated(pulp, caplog):
             "[outdated_ubi_repo] UBI modulemd 'some_module1:1' version is outdated (current: 7, latest: 10)",
             "[outdated_ubi_repo] UBI modulemd_defaults 'some_module_defaults1:1' version is outdated",
             "[outdated_ubi_repo] UBI rpm 'gcc' version is outdated (current: ('0', '8.2.1', '200'), latest: ('0', '9.0.1', '200'))",
-            # we didn't add RPM 'pkg-debuginfo'
             "[outdated_ubi_repo] whitelisted content missing from UBI and/or population sources;\n\tpkg-debuginfo",
         ]
         for msg in expected_logs:

--- a/ubi_manifest/worker/common.py
+++ b/ubi_manifest/worker/common.py
@@ -20,7 +20,11 @@ def filter_whitelist(
             continue
         if is_blacklisted(pkg, blacklist):
             continue
-        if pkg.name.endswith("debuginfo") or pkg.name.endswith("debugsource"):
+        if (
+            pkg.name.endswith("debuginfo")
+            or pkg.name.endswith("debugsource")
+            or pkg.name.endswith("debuginfo-common")
+        ):
             debuginfo_whitelist.add(pkg.name)
         else:
             whitelist.add(pkg.name)


### PR DESCRIPTION
This commit adds a condition to determine when the UBI/output repo is
for debug or source content and uses it to skip modulemd and
modulemd_defaults code, as these repos aren't expected to contain any
modules.