### PR TITLE
Add healthchecks [RHELDST-23402]

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1754,13 +1754,13 @@ rpds-py = ">=0.7.0"
 
 [[package]]
 name = "requests"
-version = "2.32.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.0-py3-none-any.whl", hash = "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"},
-    {file = "requests-2.32.0.tar.gz", hash = "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -1772,6 +1772,23 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-mock"
+version = "1.12.1"
+description = "Mock out responses from the requests package"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401"},
+    {file = "requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563"},
+]
+
+[package.dependencies]
+requests = ">=2.22,<3"
+
+[package.extras]
+fixture = ["fixtures"]
 
 [[package]]
 name = "rich"
@@ -2160,6 +2177,20 @@ files = [
     {file = "tomlkit-0.12.4-py3-none-any.whl", hash = "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b"},
     {file = "tomlkit-0.12.4.tar.gz", hash = "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"},
 ]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20240712"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-requests-2.32.0.20240712.tar.gz", hash = "sha256:90c079ff05e549f6bf50e02e910210b98b8ff1ebdd18e19c873cd237737c1358"},
+    {file = "types_requests-2.32.0.20240712-py3-none-any.whl", hash = "sha256:f754283e152c752e46e70942fa2a146b5bc70393522257bb85bd1ef7e019dcc3"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
 
 [[package]]
 name = "typing-extensions"
@@ -2593,4 +2624,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "ae135f71c3bb0aba6f3a34295bce1085b85c4f3b35eeb59caff1581e6d86e9dc"
+content-hash = "bf5285b8a737b35a57c930070d292969b7caaf395d8ec5744eaa332aeb5d6512"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ pubtools-pulplib = "*"
 attrs = "*"
 more-executors = "*"
 ubi-config = "*"
+requests = "^2.32.3"
+types-requests = "^2.32.0.20240712"
 
 
 [tool.poetry.group.test]
@@ -37,6 +39,7 @@ httpx = "*"
 testfixtures = "*"
 rpmdyn = "*"
 bandit = "*"
+requests-mock = "^1.12.1"
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,9 @@
 import json
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 from attr import define
-from unittest import mock
 
 from .utils import MockedRedis, create_and_insert_repo, create_mock_configs
 

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -119,3 +119,21 @@ def test_get_repo_groups(pulp):
         "8-aarch64": {"ubi8_repo1_for_aarch64", "ubi8_repo2_for_aarch64"},
         "8-x86_64": {"ubi8_repo1_for_x86_64"},
     }
+
+
+@pytest.mark.parametrize(
+    "config,expected_result",
+    [
+        (
+            {
+                "ubi": "https://gitlab.com/ubi",
+                "client-tools": "https://gitlab.com/client-tools",
+            },
+            "https://gitlab.com",
+        ),
+        ({"ubi": "/path/to/ubi/", "client-tools": ".path/to/client-tools/"}, None),
+    ],
+)
+def test_get_gitlab_base_url(config, expected_result):
+    result = utils.get_gitlab_base_url(config)
+    assert result == expected_result

--- a/tests/test_celery_beat_healthcheck.py
+++ b/tests/test_celery_beat_healthcheck.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from ubi_manifest.worker.tasks import celery_beat_healthcheck
+from .utils import MockedRedis
+import json
+
+
+@patch("ubi_manifest.worker.tasks.celery_beat_healthcheck.datetime")
+@patch("ubi_manifest.worker.tasks.celery_beat_healthcheck.redis.from_url")
+def test_beat_healthcheck_task(mock_redis, mock_datetime):
+    redis = MockedRedis(data={})
+    mock_redis.return_value = redis
+    mock_datetime.now.return_value = datetime(2024, 8, 27, 11, 22, 56, 961242)
+
+    celery_beat_healthcheck.beat_healthcheck_task()
+
+    result = redis.get("celery-beat-heartbeat")
+    assert result == "2024-08-27T11:22:56.961242"

--- a/tests/test_celery_beat_healthcheck.py
+++ b/tests/test_celery_beat_healthcheck.py
@@ -1,9 +1,10 @@
+import json
 from datetime import datetime
 from unittest.mock import patch
 
 from ubi_manifest.worker.tasks import celery_beat_healthcheck
+
 from .utils import MockedRedis
-import json
 
 
 @patch("ubi_manifest.worker.tasks.celery_beat_healthcheck.datetime")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import redis
 import ubiconfig
 from attrs import define
 from pubtools.pulplib import RpmDependency, YumRepository
@@ -105,6 +106,7 @@ class MockLoader:
 @define
 class MockedRedis:
     data: dict
+    ping_fail: bool = False
 
     def set(self, key: str, value: str, **kwargs) -> None:
         self.data[key] = value
@@ -114,6 +116,11 @@ class MockedRedis:
 
     def keys(self) -> list[str]:
         return list(self.data.keys())
+
+    def ping(self) -> bool:
+        if self.ping_fail:
+            raise ConnectionError("Connection refused.")
+        return True
 
 
 def rpmdeps_from_names(*names):

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -13,15 +13,10 @@ from .models import (
     DepsolveItem,
     DepsolverResult,
     DepsolverResultItem,
-    TaskState,
     StatusResult,
+    TaskState,
 )
-from .utils import (
-    get_items_for_depsolving,
-    get_repo_classes,
-    get_gitlab_base_url,
-)
-
+from .utils import get_gitlab_base_url, get_items_for_depsolving, get_repo_classes
 
 REQUEST_TIMEOUT = 20
 

--- a/ubi_manifest/app/models.py
+++ b/ubi_manifest/app/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 
 
@@ -20,3 +22,12 @@ class DepsolverResultItem(BaseModel):
 class DepsolverResult(BaseModel):
     repo_id: str
     content: list[DepsolverResultItem]
+
+
+class StatusResult(BaseModel):
+    server_status: str
+    workers_status: dict[str, Any]
+    redis_status: dict[str, str]
+    celery_beat_status: dict[str, str]
+    connection_to_gitlab: dict[str, str]
+    connection_to_pulp: dict[str, str]

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+from typing import Any, Optional
+from urllib.parse import urlparse
 
 import ubiconfig
 from pubtools.pulplib import Client, Criteria
@@ -153,3 +154,18 @@ def get_repo_ids_from_cs(client: Client, ubi_binary_cs: str) -> Any:
         )
     )
     return repos
+
+
+def get_gitlab_base_url(config: dict[str, str]) -> Optional[str]:
+    """
+    Returns gitlab base url if the content configs are loaded from gitlab.
+    Returns None if the content configs are loaded from directory.
+    """
+    for config_path in config.values():
+        parsed = urlparse(config_path)
+        # if there is a scheme, content config is passed from Gitlab so
+        # return the base url on which to do healthchek
+        if parsed.scheme:
+            return f"{parsed.scheme}://{parsed.netloc}"
+    # otherwise content config is passed from directory, therefore no healthcheck is needed
+    return None

--- a/ubi_manifest/worker/tasks/celery_beat_healthcheck.py
+++ b/ubi_manifest/worker/tasks/celery_beat_healthcheck.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+import redis
+
+from ubi_manifest.worker.tasks.celery import app
+
+
+@app.task  # type: ignore [misc]  # ignore untyped decorator
+def beat_healthcheck_task() -> None:
+    """
+    This task updates 'celery-beat-heartbeat' value in redis with current time every minute.
+    It is used for healthcheck of the celery beat schedule.
+    """
+    redis_client = redis.from_url(app.conf.result_backend)
+    redis_client.set("celery-beat-heartbeat", datetime.now().isoformat())

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -51,7 +51,8 @@ def validate_repo_groups(
 @define
 class Config:
     pulp_url: str = field(
-        validator=validators.matches_re(URL_REGEX, re.VERBOSE), default="some_url"
+        validator=validators.matches_re(URL_REGEX, re.VERBOSE),
+        default="https://some_url",
     )
     pulp_username: str = field(
         validator=validators.matches_re(USERNAME_REGEX), default="username"
@@ -77,6 +78,7 @@ class Config:
         "ubi_manifest.worker.tasks.depsolve",
         "ubi_manifest.worker.tasks.repo_monitor",
         "ubi_manifest.worker.tasks.content_audit",
+        "ubi_manifest.worker.tasks.celery_beat_healthcheck",
     ]
     broker_url: str = field(
         validator=validators.matches_re(URL_REGEX, re.VERBOSE),
@@ -100,6 +102,12 @@ class Config:
             "task": "ubi_manifest.worker.tasks.content_audit.content_audit_task",
             "schedule": int(
                 os.getenv("UBI_MANIFEST_CONTENT_AUDIT_SCHEDULE", str((3 * 60) * 60))
+            ),  # in seconds
+        },
+        "beat-healthcheck-every-N-minutes": {
+            "task": "ubi_manifest.worker.tasks.celery_beat_healthcheck.beat_healthcheck_task",
+            "schedule": int(
+                os.getenv("UBI_MANIFEST_BEAT_HEALTHCHECK", str(60))
             ),  # in seconds
         },
     }


### PR DESCRIPTION
This commit extends the `/status` endpoint to also check the status of workers, redis, celery beat and connection to gitlab and pulp.