### PR TITLE
Comply to newer versions of pylint [RHELDST-26606] 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,4 +8,5 @@ disable=fixme,
         too-many-instance-attributes,
         too-many-statements,
         too-many-arguments,
+        too-many-positional-arguments,
         

--- a/poetry.lock
+++ b/poetry.lock
@@ -60,13 +60,13 @@ trio = ["trio (>=0.23)"]
 
 [[package]]
 name = "astroid"
-version = "3.1.0"
+version = "3.3.4"
 description = "An abstract syntax tree for Python with inference support."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "astroid-3.1.0-py3-none-any.whl", hash = "sha256:951798f922990137ac090c53af473db7ab4e70c770e6d7fae0cec59f74411819"},
-    {file = "astroid-3.1.0.tar.gz", hash = "sha256:ac248253bfa4bd924a0de213707e7ebeeb3138abeb48d798784ead1e56d419d4"},
+    {file = "astroid-3.3.4-py3-none-any.whl", hash = "sha256:5eba185467253501b62a9f113c263524b4f5d55e1b30456370eed4cdbd6438fd"},
+    {file = "astroid-3.3.4.tar.gz", hash = "sha256:e73d0b62dd680a7c07cb2cd0ce3c22570b044dd01bd994bc3a2dd16c6cbba162"},
 ]
 
 [package.dependencies]
@@ -1563,17 +1563,17 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "3.1.0"
+version = "3.3.1"
 description = "python code static checker"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "pylint-3.1.0-py3-none-any.whl", hash = "sha256:507a5b60953874766d8a366e8e8c7af63e058b26345cfcb5f91f89d987fd6b74"},
-    {file = "pylint-3.1.0.tar.gz", hash = "sha256:6a69beb4a6f63debebaab0a3477ecd0f559aa726af4954fc948c51f7a2549e23"},
+    {file = "pylint-3.3.1-py3-none-any.whl", hash = "sha256:2f846a466dd023513240bc140ad2dd73bfc080a5d85a710afdb728c420a5a2b9"},
+    {file = "pylint-3.3.1.tar.gz", hash = "sha256:9f3dcc87b1203e612b78d91a896407787e708b3f189b5fa0b307712d49ff0c6e"},
 ]
 
 [package.dependencies]
-astroid = ">=3.1.0,<=3.2.0-dev0"
+astroid = ">=3.3.4,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},

--- a/ubi_manifest/worker/tasks/config.py
+++ b/ubi_manifest/worker/tasks/config.py
@@ -22,7 +22,10 @@ def validate_content_config(_: AttrsInstance, attr: Any, value: dict[str, str]) 
     for repo_class, url_or_dir in value.items():
         if not re.match(REPO_CLASS_REGEX, repo_class):
             raise ValueError(
-                f"Repo classes in '{attr.name}' must match regex '{REPO_CLASS_REGEX}'. '{repo_class}' doesn't."
+                (
+                    f"Repo classes in '{attr.name}' must match regex '{REPO_CLASS_REGEX}'."
+                    f"'{repo_class}' doesn't."
+                )
             )
         url_or_dir = str(url_or_dir)
         if url_or_dir.lower().startswith(("http://", "https://")):
@@ -33,7 +36,8 @@ def validate_content_config(_: AttrsInstance, attr: Any, value: dict[str, str]) 
             value_type = "Path"
         if not re.match(regex, url_or_dir, re.VERBOSE):
             raise ValueError(
-                f"{value_type} to config in '{attr.name}' must match regex '{regex}'. '{url_or_dir}' doesn't."
+                f"{value_type} to config in '{attr.name}' must match regex '{regex}'."
+                f"'{url_or_dir}' doesn't."
             )
 
 

--- a/ubi_manifest/worker/tasks/content_audit.py
+++ b/ubi_manifest/worker/tasks/content_audit.py
@@ -73,6 +73,7 @@ def content_audit_task() -> None:
             in_repos = client.search_repository(
                 Criteria.with_id(out_repo.population_sources)
             )
+            modular_rpm_filenames = set()
             if has_modules:
                 modular_rpm_filenames = get_pkgs_from_all_modules(
                     list(in_repos) + [out_repo]

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -208,6 +208,7 @@ def _save(data: dict[str, list[UbiUnit]]) -> None:
     for repo_id, units in data.items():
         items = []
         for unit in units:
+            item = {}
             if unit.isinstance_inner_unit(RpmUnit):
                 item = {
                     "src_repo_id": unit.associate_source_repo_id,
@@ -229,6 +230,8 @@ def _save(data: dict[str, list[UbiUnit]]) -> None:
                     "unit_attr": "name:stream",
                     "value": f"{unit.name}:{unit.stream}",
                 }
+            else:
+                continue
             items.append(item)
 
         data_for_redis[repo_id] = items


### PR DESCRIPTION
+ Change .pylintrc to ignore `too-many-positional-arguments`
+ Assign variables by default when they are possibly unbound