### PR TITLE
Add arch to outdated warning log [RHELDST-13955]

### DIFF
--- a/tests/test_content_audit_task.py
+++ b/tests/test_content_audit_task.py
@@ -219,7 +219,7 @@ def test_pipeline(pulp, caplog):
             expected_ubi_binary_repo_1 = [
                 f"Processing and auditing UBI repo '{ubi_binary_repo_1.id}' with modular content...",
                 "Only auditing of non modular content has been implemented.",
-                f"[{ubi_binary_repo_1.id}] UBI rpm 'gcc' is outdated (current: ('0', '8.2.1', '200'), latest: ('0', '9.0.1', '200'))",
+                f"[{ubi_binary_repo_1.id}] UBI rpm of {ubi_binary_repo_1.arch} 'gcc' is outdated (current: ('0', '8.2.1', '200'), latest: ('0', '9.0.1', '200'))",
                 f"[{ubi_binary_repo_1.id}] Whitelisted package 'neovim' found in out repo but not in any input repos!",
                 f"[{ubi_binary_repo_1.id}] Whitelisted package 'bash' found in input repos but not in output repo!",
             ]

--- a/ubi_manifest/worker/tasks/auditing.py
+++ b/ubi_manifest/worker/tasks/auditing.py
@@ -78,10 +78,12 @@ class NonModularAuditor:
 
         def log_warning(
             warn_tuple: tuple[str, tuple[str, str, str], tuple[str, str, str]],
+            arch: str,
         ) -> None:
             _LOG.warning(
-                "[%s] UBI rpm '%s' is outdated (current: %s, latest: %s)",
+                "[%s] UBI rpm of %s '%s' is outdated (current: %s, latest: %s)",
                 self.out_repo_id,
+                arch,
                 *warn_tuple,
             )
 
@@ -96,7 +98,7 @@ class NonModularAuditor:
                 out_evr,
                 in_evr,
             ):  # type: ignore
-                log_warning((out_unit.name, out_evr, in_evr))
+                log_warning((out_unit.name, out_evr, in_evr), name_arch[1])
 
     def check_content_rules(self) -> None:
         """


### PR DESCRIPTION
Add architecture in the message displayed when a warning is logged by the content auditor for outdated packages.

The previous message was ambiguous for seemingly identical packages, but with different architecture, current log is more verbose.