### PR TITLE
Add SRPM content audit [RHELDST-33439]

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,13 @@ class MockLoader:
                     "bash.*",
                     "neovim.*",
                 ],
-                "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],
+                "exclude": [
+                    "package-name*.*",
+                    "kernel",
+                    "kernel.x86_64",
+                    "kernel.src",
+                    "gcc.src",
+                ],
             },
             "content_sets": {
                 "rpm": {"output": "cs_rpm_out", "input": "cs_rpm_in"},
@@ -94,7 +100,13 @@ class MockLoader:
                     "neovim.*",
                     "bash.*",
                 ],
-                "exclude": ["package-name*.*", "kernel", "kernel.x86_64"],
+                "exclude": [
+                    "package-name*.*",
+                    "kernel",
+                    "kernel.x86_64",
+                    "kernel.src",
+                    "gcc.src",
+                ],
             },
             "content_sets": {
                 "rpm": {"output": "cs_rpm_out", "input": "cs_rpm_in_other"},


### PR DESCRIPTION
Adds SRPM content auditing:

- Verifies that all bin and debug packages have a matching SRPM package in the source repo
  -  Logs a warning for any packages missing from the source repo
- Verifies that no blacklisted SRPMs are present in the source repo
  - Logs a warning when blacklisted SRPMs are found