### PR TITLE
Fix parsing of .provides field [RHELDST-33631]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -82,7 +82,7 @@ def test_extract_and_resolve():
     depsolver._required_rpms = rpmdeps_from_names("pkg_a", "pkg_b")
     depsolver._provided_rpms = rpmdeps_from_names("pkg_c", "pkg_d")
     depsolver._unsolved_rpms = rpmdeps_from_names("pkg_a", "pkg_b")
-    depsolver._required_files = {"/some/file"}
+    depsolver._required_files = {"/some/file", "/other/file"}
 
     unit = RpmUnit(
         name="test",
@@ -90,7 +90,11 @@ def test_extract_and_resolve():
         release="200",
         epoch="1",
         arch="x86_64",
-        provides=[RpmDependency(name="pkg_e"), RpmDependency(name="pkg_b")],
+        provides=[
+            RpmDependency(name="pkg_e"),
+            RpmDependency(name="pkg_b"),
+            RpmDependency(name="/other/file"),
+        ],
         requires=[RpmDependency(name="pkg_f"), RpmDependency(name="(pkg_g if pkg_h)")],
         files=["/some/file"],
     )

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -133,7 +133,10 @@ class Depsolver:
 
             for item in rpm.provides:
                 # add to global provides
-                self._provided_rpms.add(item)
+                if item.name.startswith("/"):
+                    self._provided_files.add(item)
+                else:
+                    self._provided_rpms.add(item)
 
             for filename in rpm.files or []:
                 self._provided_files.add(RpmDependency(name=filename))


### PR DESCRIPTION
Previously, all items from .provides field were treated as provided_rpms. However, some of those items are files, not rpms. This commit therefore updates the parsing of .provides field, so the items are sorted into provided_rpms and provided_files.