### PR TITLE
Lower log level for blacklisted deps [RHELDST-33629]

### DIFF
--- a/tests/test_depsolver.py
+++ b/tests/test_depsolver.py
@@ -322,13 +322,13 @@ def test_run(pulp):
                 ),
                 (
                     "ubi_manifest.worker.tasks.depsolver.rpm_depsolver",
-                    "WARNING",
+                    "INFO",
                     "Failed depsolving: lib_exclude is blacklisted. These rpms depend on it"
                     " ['lib-x-100-200.x86_64.rpm', 'lib-y-100-200.x86_64.rpm']",
                 ),
                 (
                     "ubi_manifest.worker.tasks.depsolver.rpm_depsolver",
-                    "WARNING",
+                    "INFO",
                     "Failed depsolving: blacklisted-package is blacklisted."
                     " These rpms depend on it ['lib-y-100-200.x86_64.rpm']",
                 ),

--- a/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
+++ b/ubi_manifest/worker/tasks/depsolver/rpm_depsolver.py
@@ -339,7 +339,8 @@ class Depsolver:
 
             # Divide missing dependencies blacklisted and all others
             if any((_is_blacklisted_by_rule(item, rule) for rule in merged_blacklist)):
-                _LOG.warning(
+                # This is expected, so logging is only at the info level
+                _LOG.info(
                     "Failed depsolving: %s is blacklisted. These rpms depend on it %s",
                     item,
                     sorted(depending_rpms),


### PR DESCRIPTION
Previously, logging blacklisted dependencies as warnings triggered unnecessary alerts, creating ~2.3% noise of depsolver warnings. This change reduces the log level to INFO to treat this as expected behavior, eliminating false alerts while still keeping the logs available for debugging.