### PR TITLE
Delete unused type: ignore comments [RHELDST-34308]

### DIFF
--- a/ubi_manifest/worker/tasks/auditing.py
+++ b/ubi_manifest/worker/tasks/auditing.py
@@ -101,7 +101,7 @@ class NonModularAuditor:
             if RELATION_CMP_MAP["LT"](
                 out_evr,
                 in_evr,
-            ):  # type: ignore
+            ):
                 log_warning((out_unit.name, out_evr, in_evr), name_arch[1])
 
     def verify_blacklist(self, is_src_repo: bool = False) -> None:

--- a/ubi_manifest/worker/utils.py
+++ b/ubi_manifest/worker/utils.py
@@ -211,7 +211,7 @@ def is_requirement_resolved(req: RpmDependency, provider: RpmDependency) -> Any:
         req_evr = (req.epoch, req.version, req.release)
         prov_evr = (provider.epoch, provider.version, provider.release)
         # compare provider with requirement
-        out = RELATION_CMP_MAP[req.flags](prov_evr, req_evr)  # type: ignore [no-untyped-call]
+        out = RELATION_CMP_MAP[req.flags](prov_evr, req_evr)
 
     else:
         # without flags we just compare names


### PR DESCRIPTION
Following the update of Mypy to a newer version, two new errors were raised for unused 'type: ignore' comments. This commit therefore deletes the redundant suppression comment from auditing.py and the error code suppression from utils.py. These comments are no longer necessary as the underlying type issues have been resolved or Mypy now correctly infers the types.