### PR TITLE
Complete branch_prefix implementation

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -314,8 +314,8 @@ def test_manifest_post_full_dep(
         MockAsyncResult(task_id="foo-bar-id-2", state="PENDING"),
     ]
     get_content_configs.return_value = [
-        {"source": "url_or_dir_1"},
-        {"source": "url_or_dir_2"},
+        {"source": "url_or_dir_1", "branch_prefix":"foo"},
+        {"source": "url_or_dir_2", "branch_prefix":"bar"},
     ]
     ubi_configs = create_mock_configs(3, prefix="ubi")
     ct_configs = create_mock_configs(3, prefix="client-tools")
@@ -362,8 +362,8 @@ def test_manifest_post_full_dep(
     # present in 'ubi_repo_2'.
     mocked_apply_async.assert_has_calls(
         [
-            mock.call(args=[["ubi_repo_1", "ubi_repo_2"], "url_or_dir_1"]),
-            mock.call(args=[["ubi_repo_3"], "url_or_dir_1"]),
+            mock.call(args=[["ubi_repo_1", "ubi_repo_2"], "url_or_dir_1", 'foo']),
+            mock.call(args=[["ubi_repo_3"], "url_or_dir_1", 'foo']),
         ]
     )
     # expected status code is 201
@@ -396,8 +396,8 @@ def test_manifest_post_not_full_dep(
         MockAsyncResult(task_id="foo-bar-id-2", state="PENDING"),
     ]
     get_content_configs.return_value = [
-        {"source": "url_or_dir_1"},
-        {"source": "url_or_dir_2"},
+        {"source": "url_or_dir_1", "branch_prefix":"foo"},
+        {"source": "url_or_dir_2", "branch_prefix":"bar"},
     ]
     ct_configs = create_mock_configs(
         2, flags={"base_pkgs_only": True}, prefix="client-tools"
@@ -434,8 +434,8 @@ def test_manifest_post_not_full_dep(
     # determined and the depsolving is performed separately for each repo.
     mocked_apply_async.assert_has_calls(
         [
-            mock.call(args=[["client-tools_repo_1"], "url_or_dir_2"]),
-            mock.call(args=[["client-tools_repo_2"], "url_or_dir_2"]),
+            mock.call(args=[["client-tools_repo_1"], "url_or_dir_2", 'bar']),
+            mock.call(args=[["client-tools_repo_2"], "url_or_dir_2", 'bar']),
         ]
     )
     # expected status code is 201

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -314,8 +314,8 @@ def test_manifest_post_full_dep(
         MockAsyncResult(task_id="foo-bar-id-2", state="PENDING"),
     ]
     get_content_configs.return_value = [
-        {"source": "url_or_dir_1", "branch_prefix":"foo"},
-        {"source": "url_or_dir_2", "branch_prefix":"bar"},
+        {"source": "url_or_dir_1", "branch_prefix": "foo"},
+        {"source": "url_or_dir_2", "branch_prefix": "bar"},
     ]
     ubi_configs = create_mock_configs(3, prefix="ubi")
     ct_configs = create_mock_configs(3, prefix="client-tools")
@@ -362,8 +362,8 @@ def test_manifest_post_full_dep(
     # present in 'ubi_repo_2'.
     mocked_apply_async.assert_has_calls(
         [
-            mock.call(args=[["ubi_repo_1", "ubi_repo_2"], "url_or_dir_1", 'foo']),
-            mock.call(args=[["ubi_repo_3"], "url_or_dir_1", 'foo']),
+            mock.call(args=[["ubi_repo_1", "ubi_repo_2"], "url_or_dir_1", "foo"]),
+            mock.call(args=[["ubi_repo_3"], "url_or_dir_1", "foo"]),
         ]
     )
     # expected status code is 201
@@ -396,8 +396,8 @@ def test_manifest_post_not_full_dep(
         MockAsyncResult(task_id="foo-bar-id-2", state="PENDING"),
     ]
     get_content_configs.return_value = [
-        {"source": "url_or_dir_1", "branch_prefix":"foo"},
-        {"source": "url_or_dir_2", "branch_prefix":"bar"},
+        {"source": "url_or_dir_1", "branch_prefix": "foo"},
+        {"source": "url_or_dir_2", "branch_prefix": "bar"},
     ]
     ct_configs = create_mock_configs(
         2, flags={"base_pkgs_only": True}, prefix="client-tools"
@@ -434,8 +434,8 @@ def test_manifest_post_not_full_dep(
     # determined and the depsolving is performed separately for each repo.
     mocked_apply_async.assert_has_calls(
         [
-            mock.call(args=[["client-tools_repo_1"], "url_or_dir_2", 'bar']),
-            mock.call(args=[["client-tools_repo_2"], "url_or_dir_2", 'bar']),
+            mock.call(args=[["client-tools_repo_1"], "url_or_dir_2", "bar"]),
+            mock.call(args=[["client-tools_repo_2"], "url_or_dir_2", "bar"]),
         ]
     )
     # expected status code is 201

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -39,7 +39,40 @@ def test_get_content_configs_from_content_config(mock_app):
     ]
 
 
-def test_get_items_from_groups():
+@pytest.mark.parametrize(
+    "branch_prefix,expected",
+    [
+        (
+            None,
+            [
+                {
+                    "repo_group": ["ubi_repo4", "ubi_repo5", "ubi_repo6"],
+                    "url": "https://ubi",
+                },
+                {
+                    "repo_group": ["ubi_repo7", "ubi_repo8", "ubi_repo9"],
+                    "url": "https://ubi",
+                },
+            ],
+        ),
+        (
+            "my-branch",
+            [
+                {
+                    "repo_group": ["ubi_repo4", "ubi_repo5", "ubi_repo6"],
+                    "url": "https://ubi",
+                    "branch_prefix": "my-branch",
+                },
+                {
+                    "repo_group": ["ubi_repo7", "ubi_repo8", "ubi_repo9"],
+                    "url": "https://ubi",
+                    "branch_prefix": "my-branch",
+                },
+            ],
+        ),
+    ],
+)
+def test_get_items_from_groups(branch_prefix, expected):
     repo_groups = {
         "7-aarch64": {"ubi_repo1", "ubi_repo2", "ubi_repo3"},
         "8-aarch64": {"ubi_repo4", "ubi_repo5", "ubi_repo6"},
@@ -47,18 +80,71 @@ def test_get_items_from_groups():
     }
     repo_ids = ["ubi_repo4", "ubi_repo5", "ubi_repo9"]
 
-    result = utils.get_items_from_groups(repo_ids, repo_groups, "https://ubi")
+    result = utils.get_items_from_groups(
+        repo_ids, repo_groups, "https://ubi", branch_prefix
+    )
 
-    assert result == [
-        {
-            "repo_group": ["ubi_repo4", "ubi_repo5", "ubi_repo6"],
-            "url": "https://ubi",
-        },
-        {
-            "repo_group": ["ubi_repo7", "ubi_repo8", "ubi_repo9"],
-            "url": "https://ubi",
-        },
-    ]
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "branch_prefix,expected_items",
+    [
+        (
+            None,
+            [
+                {"repo_group": ["ubi_repo1"], "url": "https://ubi"},
+                {"repo_group": ["ubi_repo2"], "url": "https://ubi"},
+            ],
+        ),
+        (
+            "test-branch",
+            [
+                {
+                    "repo_group": ["ubi_repo1"],
+                    "url": "https://ubi",
+                    "branch_prefix": "test-branch",
+                },
+                {
+                    "repo_group": ["ubi_repo2"],
+                    "url": "https://ubi",
+                    "branch_prefix": "test-branch",
+                },
+            ],
+        ),
+    ],
+)
+def test_get_items_not_full_depsolving(pulp, branch_prefix, expected_items):
+    configs = create_mock_configs(2)
+    create_and_insert_repo(
+        id="ubi_repo1",
+        content_set="content_set_0",
+        ubi_population=True,
+        arch="x86_64",
+        pulp=pulp,
+    )
+    create_and_insert_repo(
+        id="ubi_repo2",
+        content_set="content_set_1",
+        ubi_population=True,
+        arch="x86_64",
+        pulp=pulp,
+    )
+    create_and_insert_repo(
+        id="ubi_repo3",
+        content_set="content_set_other",
+        ubi_population=True,
+        arch="x86_64",
+        pulp=pulp,
+    )
+
+    repo_ids = ["ubi_repo1", "ubi_repo2", "ubi_repo_nonexistent"]
+
+    result = utils.get_items_not_full_depsolving(
+        pulp.client, configs, repo_ids, "https://ubi", branch_prefix
+    )
+
+    assert result == expected_items
 
 
 @patch("ubiconfig.get_loader")

--- a/ubi_manifest/app/api.py
+++ b/ubi_manifest/app/api.py
@@ -183,7 +183,9 @@ def manifest_post(depsolve_item: DepsolveItem) -> list[TaskState]:
 
     tasks_states = []
     for item in depsolve_items:
-        task = depsolve_task.apply_async(args=[item["repo_group"], item["url"]])
+        task = depsolve_task.apply_async(
+            args=[item["repo_group"], item["url"], item.get("branch_prefix", "")]
+        )
         tasks_states.append(TaskState(task_id=task.task_id, state=task.state))
 
     return tasks_states

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -16,7 +16,7 @@ class FlagInconsistencyError(ValueError):
     pass
 
 
-def get_content_configs() -> list[dict]:
+def get_content_configs() -> list[dict[str, Any]]:
     """
     Returns list of content config parameters loaded from cdn-definitions.
 
@@ -68,19 +68,21 @@ def get_items_for_depsolving(
         content_sync_configs = get_content_configs()
         for config in content_sync_configs:
             config_url = str(config.get("source"))
-            config_branch = config.get("branch_prefix", None)
-            configs = get_configs(config_url, config_branch)
+            config_branch_prefix = config.get("branch_prefix", None)
+            configs = get_configs(config_url, config_branch_prefix)
             if not configs:
                 continue
 
             base_pkg_only = check_and_get_flag(configs, config_url)
             if base_pkg_only:
                 items = get_items_not_full_depsolving(
-                    client, configs, repo_ids, config_url
+                    client, configs, repo_ids, config_url, config_branch_prefix
                 )
             else:
                 repo_groups = get_repo_groups(client, configs)
-                items = get_items_from_groups(repo_ids, repo_groups, config_url)
+                items = get_items_from_groups(
+                    repo_ids, repo_groups, config_url, config_branch_prefix
+                )
 
             all_items.extend(items)
 
@@ -89,7 +91,10 @@ def get_items_for_depsolving(
 
 
 def get_items_from_groups(
-    repo_ids: list[str], repo_groups: dict[str, set[str]], config_url: str
+    repo_ids: list[str],
+    repo_groups: dict[str, set[str]],
+    config_url: str,
+    branch_prefix: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     """
     Returns a list of items for depsolving based on the given repo groups.
@@ -104,12 +109,15 @@ def get_items_from_groups(
                 break
     # Create items for depsolving
     for repo_group in needed_repo_groups.values():
-        items.append({"repo_group": list(sorted(repo_group)), "url": config_url})
+        item = {"repo_group": list(sorted(repo_group)), "url": config_url}
+        if branch_prefix:
+            item["branch_prefix"] = branch_prefix
+        items.append(item)
 
     return items
 
 
-def get_configs(url: str, branch_prefix: str = None) -> Any:
+def get_configs(url: str, branch_prefix: Optional[str] = None) -> Any:
     """
     Returns configs from the given url.
     """
@@ -137,7 +145,11 @@ def check_and_get_flag(configs: list[Any], url: str) -> Any:
 
 
 def get_items_not_full_depsolving(
-    client: Client, configs: list[Any], repo_ids: list[str], config_url: str
+    client: Client,
+    configs: list[Any],
+    repo_ids: list[str],
+    config_url: str,
+    branch_prefix: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     """
     Returns a list of items for depsolving for repos where we don't use full depsolving.
@@ -154,7 +166,10 @@ def get_items_not_full_depsolving(
     # and create items for depsolving for each present repo
     for repo_id in repo_ids:
         if repo_id in pulp_repo_ids:
-            items.append({"repo_group": [repo_id], "url": config_url})
+            item = {"repo_group": [repo_id], "url": config_url}
+            if branch_prefix:
+                item["branch_prefix"] = branch_prefix
+            items.append(item)
     return items
 
 

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -45,7 +45,9 @@ class InconsistentDepsolverConfig(Exception):
 
 
 @app.task  # type: ignore [misc]  # ignore untyped decorator
-def depsolve_task(ubi_repo_ids: Iterable[str], content_config_url: str) -> None:
+def depsolve_task(
+    ubi_repo_ids: Iterable[str], content_config_url: str, branch_prefix: str = ""
+) -> None:
     """
     Run depsolvers for given ubi_repo_ids - it's expected that id of binary
     repositories are provided. Debuginfo and SRPM repos related to those ones
@@ -56,7 +58,7 @@ def depsolve_task(ubi_repo_ids: Iterable[str], content_config_url: str) -> None:
     (source_repo_id, unit_type, unit_attr, value). Note that value in redis
     is stored as json string.
     """
-    ubi_config_loader = UbiConfigLoader(content_config_url)
+    ubi_config_loader = UbiConfigLoader(content_config_url, branch_prefix)
 
     with make_pulp_client(app.conf) as client:
         depsolver_flags = {}  # (input_cs, ubi_repo_id): {"flag_x": "value"}


### PR DESCRIPTION
It was missing in depsolve_task and manifest endpoint. This PR adds missing branch_prefix support to depsolve_task and manifest endpoint.