### PR TITLE
Add additional tags to push build pipeline [RHELDST-39227]

### DIFF
--- a/.tekton/ubi-manifest-app-push.yaml
+++ b/.tekton/ubi-manifest-app-push.yaml
@@ -448,6 +448,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - "$(tasks.clone-repository.results.commit-timestamp)"
+        - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/ubi_manifest/app/utils.py
+++ b/ubi_manifest/app/utils.py
@@ -225,7 +225,7 @@ def get_gitlab_healthcheck_url() -> Optional[str]:
 
     # CDN definitions were loaded from a file, check if any sync repo is on GitLab
     for configs in get_content_configs():
-        config_path = configs.get("source")
+        config_path = configs["source"]
         parsed = urlparse(config_path)
         # If there is a scheme, content config is loaded from an URL, so
         # we assume it is a GitLab URL and return its healthcheck URL.

--- a/ubi_manifest/worker/tasks/celery.py
+++ b/ubi_manifest/worker/tasks/celery.py
@@ -8,7 +8,7 @@ app = celery.Celery()
 make_config(app)
 
 
-@celery.signals.celeryd_init.connect  # type: ignore [misc]  # ignore untyped decorator
+@celery.signals.celeryd_init.connect  # type: ignore [untyped-decorator]
 def setup_log_format(conf: Any, **_kwargs: Any) -> None:  # pragma: no cover
     conf.worker_log_format = (
         "%(asctime)s - [%(levelname)s] - [%(name)s/%(process)d] - %(message)s"

--- a/ubi_manifest/worker/tasks/celery_beat_healthcheck.py
+++ b/ubi_manifest/worker/tasks/celery_beat_healthcheck.py
@@ -5,7 +5,7 @@ import redis
 from ubi_manifest.worker.tasks.celery import app
 
 
-@app.task  # type: ignore [misc]  # ignore untyped decorator
+@app.task  # type: ignore [untyped-decorator]
 def beat_healthcheck_task() -> None:
     """
     This task updates 'celery-beat-heartbeat' value in redis with current time every minute.

--- a/ubi_manifest/worker/tasks/depsolve.py
+++ b/ubi_manifest/worker/tasks/depsolve.py
@@ -44,7 +44,7 @@ class InconsistentDepsolverConfig(Exception):
     """
 
 
-@app.task  # type: ignore [misc]  # ignore untyped decorator
+@app.task  # type: ignore [untyped-decorator]
 def depsolve_task(
     ubi_repo_ids: Iterable[str], content_config_url: str, branch_prefix: str = ""
 ) -> None:

--- a/ubi_manifest/worker/tasks/repo_monitor.py
+++ b/ubi_manifest/worker/tasks/repo_monitor.py
@@ -11,7 +11,7 @@ from ubi_manifest.worker.utils import make_pulp_client
 _LOG = logging.getLogger(__name__)
 
 
-@app.task  # type: ignore [misc]  # ignore untyped decorator
+@app.task  # type: ignore [untyped-decorator]
 def repo_monitor_task() -> None:
     """
     This task runs various checks for relevant repositories.


### PR DESCRIPTION
This is for MintMaker to be able to track the latest dependencies in the ubi-manifest-workflows repo.
This MR also fixes the mypy errors:
1. Mypy's untyped-decorator error was recently moved from `misc` error code under its own `untyped-decorator` error code.
2. [str-bytes-safe] - the `config_path = configs.get("source")` could potentially return None, which would result in binary empty values in `parsed` and mypy complaining about the subsequent usage in f-string. However, since we are sure the "source" key will be present, I think changing it to `config_path = configs["source"]` is safe to do.