### PR TITLE
Disable updates for mypy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["pylint", "pre-commit", "uvicorn", "black"],
+      "matchPackageNames": ["pylint", "pre-commit", "uvicorn", "black", "mypy"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
* currently the automated deps update tries to update mypy but the latest version dropped support for python3.9, so let's disable updates for it now.