### PR TITLE
Update ubi-manifest-app tag

### DIFF
--- a/.tekton/ubi-manifest-app-push.yaml
+++ b/.tekton/ubi-manifest-app-push.yaml
@@ -460,7 +460,7 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: ADDITIONAL_TAGS
         value:
-        - "$(tasks.clone-repository.results.commit-timestamp)"
+        - "$(tasks.clone-repository.results.commit-timestamp)-merged"
         - latest
       runAfter:
       - build-image-index


### PR DESCRIPTION
Seems like renovate can't compare fully numerical tags out of the box and therefore can't update the dependency in the ubi-manifest-workflows.
We need to update the tag to have `*-<something>` after the timestamp, so renovate can parse it as a version and properly compare.