### PR TITLE
Update codecov-action auth and flags [RHELDST-40412]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: master
 
-
 jobs:
   py39:
     runs-on: ubuntu-latest
@@ -67,6 +66,8 @@ jobs:
         run: tox -e static
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Python
@@ -82,9 +83,11 @@ jobs:
       - name: Install pytest cov
         run: poetry run python -m pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+        uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
           fail_ci_if_error: true
           verbose: true
   bandit:


### PR DESCRIPTION
Updates codecov-action to use OIDC authentication, and adds the unit-tests flag to codecov reports.